### PR TITLE
ci: run melos analyze sequentially to avoid custom_lint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,7 +40,9 @@ melos:
     analyze:
       run: dart analyze --fatal-warnings
       exec:
-        concurrency: 4
+        # Run sequentially to avoid analyzer plugin cache race conditions
+        # (custom_lint plugin AOT snapshot truncation in CI).
+        concurrency: 1
     test:
       run: dart test
       exec:


### PR DESCRIPTION
  plugin race