### PR TITLE
Feature/otel benchmarks optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,29 +20,7 @@ on:
       - 'knex_dart_all-v*.*.*'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-  workflow_dispatch:
-    inputs:
-      publish_package:
-        description: Package to publish after CI passes.
-        required: true
-        default: none
-        type: choice
-        options:
-          - none
-          - all
-          - knex_dart
-          - knex_dart_postgres
-          - knex_dart_mysql
-          - knex_dart_sqlite
-          - knex_dart_turso
-          - knex_dart_d1
-          - knex_dart_duckdb
-          - knex_dart_snowflake
-          - knex_dart_bigquery
-          - knex_dart_mssql
-          - knex_dart_otel
-          - knex_dart_capabilities
-          - knex_dart_lint
+  workflow_dispatch: {}
 
 # Cancel in-progress runs for the same branch/PR
 concurrency:
@@ -675,7 +653,7 @@ jobs:
       - test-otel
       - test-embedded-wasm
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') || (github.event_name == 'workflow_dispatch' && inputs.publish_package != 'none' && github.ref == 'refs/heads/main')
+    if: startsWith(github.ref, 'refs/tags/')
     environment: pub.dev
     permissions:
       id-token: write
@@ -686,11 +664,6 @@ jobs:
         id: resolve
         shell: bash
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "package=${{ inputs.publish_package }}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           TAG="${GITHUB_REF_NAME}"
           case "$TAG" in
             knex_dart-v*)              echo "package=knex_dart" ;;
@@ -724,10 +697,10 @@ jobs:
           melos-version: ^7.0.0
       - name: Publish dry-run
         if: steps.resolve.outputs.package != 'all'
-        run: melos publish --scope="${{ steps.resolve.outputs.package }}" --no-private --yes
+        run: melos publish --scope="${{ steps.resolve.outputs.package }}" --no-private --dry-run --yes
       - name: Publish dry-run (all)
         if: steps.resolve.outputs.package == 'all'
-        run: melos publish --no-private --yes
+        run: melos publish --no-private --dry-run --yes
       - name: Publish
         if: steps.resolve.outputs.package != 'all'
         run: melos publish --scope="${{ steps.resolve.outputs.package }}" --no-private --no-dry-run --yes

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ build/
 custom_lint.log
 example/lint_demo/custom_lint.log
 mssql_connection_issue.md
+benchmarks/results/
 
 # Playground
 playground/node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.2.1
+
+- Improved core SQL generation hot paths and SQLite wrapper execution overhead.
+- Documented the core query interceptor pipeline used by live driver wrappers.
+- Added OpenTelemetry span attribute verification tests and a real SDK SQLite
+  export example for `knex_dart_otel`.
+- Added a private benchmark workspace package for SQL generation, SQLite live
+  execution, and API-cost matrix benchmarking.
+
 ## 1.1.0
 
 - Added filesystem/config migration source support via `fromConfig()`.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help db-up db-down test-all test-postgres test-mysql test-sqlite test-duckdb test-mssql test-turso test-bigquery test-d1 test-snowflake test-unit analyze coverage
+.PHONY: help db-up db-down test-all test-postgres test-mysql test-sqlite test-duckdb test-mssql test-turso test-bigquery test-d1 test-snowflake test-unit analyze coverage bench-sql bench-sqlite bench-matrix bench-all example-otel-sqlite
 
 # Local development only — not used in CI.
 # CI uses `dart test --tags=<driver>` directly against GitHub Actions service containers.
@@ -59,3 +59,17 @@ coverage: ## Generate coverage/lcov.info for core package
 	else \
 		sed -i 's|SF:.*/packages/knex_dart/lib|SF:packages/knex_dart/lib|' coverage/lcov.info; \
 	fi
+
+bench-sql:
+	dart run benchmarks/bin/sql_generation.dart
+
+bench-sqlite:
+	dart run benchmarks/bin/sqlite_live.dart
+
+bench-matrix:
+	dart run benchmarks/bin/run_matrix.dart
+
+bench-all: bench-sql bench-sqlite bench-matrix
+
+example-otel-sqlite:
+	cd examples/knex_otel_sqlite_app && dart run bin/sqlite_otel_collector.dart

--- a/benchmarks/bin/run_matrix.dart
+++ b/benchmarks/bin/run_matrix.dart
@@ -1,0 +1,108 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:knex_dart/knex_dart.dart';
+import 'package:knex_dart_benchmark/benchmark_case.dart';
+import 'package:knex_dart_benchmark/benchmark_runner.dart';
+import 'package:knex_dart_benchmark/dialect_cases.dart';
+import 'package:knex_dart_benchmark/reporters.dart';
+
+Future<void> main(List<String> args) async {
+  final options = _Options.parse(args);
+  final runner = BenchmarkRunner(
+    cases: sqlGenerationCases,
+    config: BenchmarkConfig(
+      iterations: options.iterations,
+      warmupIterations: options.warmupIterations,
+      dialects: options.dialects,
+      includeUnsupported: true,
+    ),
+  );
+
+  final run = runner.run();
+  final markdown = benchmarkRunToMarkdown(run);
+  final outputDir = Directory(options.outputDirectory);
+  if (!outputDir.existsSync()) {
+    outputDir.createSync(recursive: true);
+  }
+
+  File(
+    '${outputDir.path}/latest.json',
+  ).writeAsStringSync(benchmarkRunToJson(run));
+  File('${outputDir.path}/latest.md').writeAsStringSync(markdown);
+  File('${outputDir.path}/operations.json').writeAsStringSync(
+    const JsonEncoder.withIndent('  ').convert(matrixCoverageMetadata),
+  );
+
+  print(markdown);
+}
+
+class _Options {
+  final int iterations;
+  final int warmupIterations;
+  final String outputDirectory;
+  final List<KnexDialect> dialects;
+
+  const _Options({
+    required this.iterations,
+    required this.warmupIterations,
+    required this.outputDirectory,
+    required this.dialects,
+  });
+
+  factory _Options.parse(List<String> args) {
+    var iterations = 10000;
+    var warmupIterations = 1000;
+    var outputDirectory = 'benchmarks/results';
+    var dialects = allBenchmarkDialects;
+
+    for (final arg in args) {
+      if (arg.startsWith('--iterations=')) {
+        iterations = _parsePositiveInt(arg, '--iterations=');
+      } else if (arg.startsWith('--warmup=')) {
+        warmupIterations = _parsePositiveInt(arg, '--warmup=');
+      } else if (arg.startsWith('--out=')) {
+        outputDirectory = arg.substring('--out='.length);
+      } else if (arg.startsWith('--dialects=')) {
+        dialects = _parseDialects(arg.substring('--dialects='.length));
+      } else {
+        throw ArgumentError('Unknown argument: $arg');
+      }
+    }
+
+    return _Options(
+      iterations: iterations,
+      warmupIterations: warmupIterations,
+      outputDirectory: outputDirectory,
+      dialects: dialects,
+    );
+  }
+
+  static int _parsePositiveInt(String arg, String prefix) {
+    final value = int.tryParse(arg.substring(prefix.length));
+    if (value == null || value <= 0) {
+      throw ArgumentError('$prefix must be a positive integer');
+    }
+    return value;
+  }
+
+  static List<KnexDialect> _parseDialects(String value) {
+    final names = value
+        .split(',')
+        .map((name) => name.trim())
+        .where((name) => name.isNotEmpty);
+    final dialects = <KnexDialect>[];
+    for (final name in names) {
+      dialects.add(
+        KnexDialect.values.firstWhere(
+          (dialect) => dialect.name == name,
+          orElse: () => throw ArgumentError('Unknown dialect: $name'),
+        ),
+      );
+    }
+    if (dialects.isEmpty) {
+      throw ArgumentError('--dialects must contain at least one dialect');
+    }
+    return dialects;
+  }
+}

--- a/benchmarks/bin/sql_generation.dart
+++ b/benchmarks/bin/sql_generation.dart
@@ -1,0 +1,207 @@
+import 'package:knex_dart/knex_dart.dart';
+
+const int _iterations = 10000;
+const int _warmupIterations = 1000;
+
+typedef SqlGeneration = SqlString Function(KnexDialect dialect);
+
+SqlString? _lastSql;
+
+class SqlOperation {
+  final String name;
+  final SqlGeneration run;
+
+  const SqlOperation(this.name, this.run);
+}
+
+class OperationResult {
+  final String fastestDialect;
+  final String slowestDialect;
+  final double ratio;
+
+  const OperationResult({
+    required this.fastestDialect,
+    required this.slowestDialect,
+    required this.ratio,
+  });
+}
+
+const _dialects = [
+  KnexDialect.postgres,
+  KnexDialect.mysql,
+  KnexDialect.sqlite,
+  KnexDialect.mariadb,
+  KnexDialect.redshift,
+  KnexDialect.turso,
+  KnexDialect.d1,
+  KnexDialect.duckdb,
+  KnexDialect.snowflake,
+  KnexDialect.bigquery,
+  KnexDialect.mssql,
+];
+
+final _operations = [
+  SqlOperation(
+    'SELECT simple',
+    (dialect) => KnexQuery.forDialect(
+      dialect,
+    ).from('users').select(['id', 'name', 'email']).toSQL(),
+  ),
+  SqlOperation(
+    'SELECT complex',
+    (dialect) => KnexQuery.forDialect(dialect)
+        .from('users')
+        .select(['*'])
+        .where('age', '>', 25)
+        .where('active', '=', true)
+        .orderBy('name', 'asc')
+        .limit(50)
+        .offset(100)
+        .toSQL(),
+  ),
+  SqlOperation(
+    'INSERT',
+    (dialect) => KnexQuery.forDialect(dialect).from('users').insert({
+      'name': 'Alice',
+      'age': 30,
+      'email': 'a@example.com',
+    }).toSQL(),
+  ),
+  SqlOperation(
+    'UPDATE',
+    (dialect) => KnexQuery.forDialect(dialect)
+        .from('users')
+        .where('id', '=', 1)
+        .update({'name': 'Bob', 'age': 31})
+        .toSQL(),
+  ),
+  SqlOperation(
+    'DELETE',
+    (dialect) => KnexQuery.forDialect(
+      dialect,
+    ).from('users').where('id', '=', 1).delete().toSQL(),
+  ),
+  SqlOperation(
+    'JOIN',
+    (dialect) => KnexQuery.forDialect(dialect)
+        .from('users')
+        .select(['users.*', 'orders.total'])
+        .join('orders', (JoinClause join) {
+          join.on('users.id', '=', 'orders.user_id');
+        })
+        .where('orders.total', '>', 100)
+        .toSQL(),
+  ),
+  SqlOperation(
+    'Subquery',
+    (dialect) => KnexQuery.forDialect(dialect).from('users').whereIn('id', (
+      QueryBuilder qb,
+    ) {
+      qb.from('orders').select(['user_id']).where('total', '>', 500);
+    }).toSQL(),
+  ),
+];
+
+Duration _time(SqlGeneration fn, KnexDialect dialect, int iterations) {
+  final sw = Stopwatch()..start();
+  for (var i = 0; i < iterations; i++) {
+    _lastSql = fn(dialect);
+  }
+  sw.stop();
+  return sw.elapsed;
+}
+
+String _dialectName(KnexDialect dialect) => dialect.name;
+
+String _formatPerOp(Duration duration) {
+  final perOp = duration.inMicroseconds / _iterations;
+  return '${perOp.toStringAsFixed(2)} µs/op';
+}
+
+String _cell(String value, int width) => value.padLeft(width);
+
+OperationResult _operationResult(
+  Map<KnexDialect, Map<String, Duration>> results,
+  String operationName,
+) {
+  var fastest = _dialects.first;
+  var slowest = _dialects.first;
+
+  for (final dialect in _dialects.skip(1)) {
+    final duration = results[dialect]![operationName]!;
+    if (duration < results[fastest]![operationName]!) {
+      fastest = dialect;
+    }
+    if (duration > results[slowest]![operationName]!) {
+      slowest = dialect;
+    }
+  }
+
+  final fastestMicros = results[fastest]![operationName]!.inMicroseconds;
+  final slowestMicros = results[slowest]![operationName]!.inMicroseconds;
+  final ratio = fastestMicros == 0 ? 0 : slowestMicros / fastestMicros;
+
+  return OperationResult(
+    fastestDialect: _dialectName(fastest),
+    slowestDialect: _dialectName(slowest),
+    ratio: ratio.toDouble(),
+  );
+}
+
+Future<void> main() async {
+  final results = <KnexDialect, Map<String, Duration>>{};
+
+  for (final dialect in _dialects) {
+    final dialectResults = <String, Duration>{};
+    for (final operation in _operations) {
+      _time(operation.run, dialect, _warmupIterations);
+      dialectResults[operation.name] = _time(
+        operation.run,
+        dialect,
+        _iterations,
+      );
+    }
+    results[dialect] = dialectResults;
+  }
+
+  print('## SQL Generation Benchmark  (10 000 iterations each)');
+  print('');
+  print(
+    '| Dialect    | SELECT simple | SELECT complex | INSERT | UPDATE | DELETE | JOIN   | Subquery |',
+  );
+  print(
+    '|------------|--------------|----------------|--------|--------|--------|--------|----------|',
+  );
+  for (final dialect in _dialects) {
+    final row = results[dialect]!;
+    print(
+      '| ${_dialectName(dialect).padRight(10)} '
+      '| ${_cell(_formatPerOp(row['SELECT simple']!), 13)} '
+      '| ${_cell(_formatPerOp(row['SELECT complex']!), 14)} '
+      '| ${_cell(_formatPerOp(row['INSERT']!), 6)} '
+      '| ${_cell(_formatPerOp(row['UPDATE']!), 6)} '
+      '| ${_cell(_formatPerOp(row['DELETE']!), 6)} '
+      '| ${_cell(_formatPerOp(row['JOIN']!), 6)} '
+      '| ${_cell(_formatPerOp(row['Subquery']!), 8)} |',
+    );
+  }
+
+  print('');
+  print('## Overhead vs fastest dialect');
+  print('');
+  print('| Operation      | Fastest | Slowest | Ratio |');
+  print('|----------------|---------|---------|-------|');
+  for (final operation in _operations) {
+    final result = _operationResult(results, operation.name);
+    print(
+      '| ${operation.name.padRight(14)} '
+      '| ${result.fastestDialect.padRight(7)} '
+      '| ${result.slowestDialect.padRight(7)} '
+      '| ${result.ratio.toStringAsFixed(1)}x  |',
+    );
+  }
+
+  if (_lastSql == null) {
+    throw StateError('benchmark produced no SQL');
+  }
+}

--- a/benchmarks/bin/sqlite_live.dart
+++ b/benchmarks/bin/sqlite_live.dart
@@ -93,15 +93,18 @@ class RawBench {
 
   Future<Duration> benchDelete() => _time(() async {
     for (var i = 0; i < _iterations; i++) {
+      _db.execute("DELETE FROM users WHERE name = 'del_$i'");
+    }
+  });
+
+  void seedDeleteRows() {
+    for (var i = 0; i < _iterations; i++) {
       _db.execute('INSERT INTO users (name, age) VALUES (?, ?)', [
         'del_$i',
         99,
       ]);
     }
-    for (var i = 0; i < _iterations; i++) {
-      _db.execute("DELETE FROM users WHERE name = 'del_$i'");
-    }
-  });
+  }
 }
 
 class KnexBench {
@@ -144,13 +147,6 @@ class KnexBench {
 
   Future<Duration> benchDelete() => _time(() async {
     for (var i = 0; i < _iterations; i++) {
-      final ins = _db.queryBuilder().table('users').insert({
-        'name': 'del_$i',
-        'age': 99,
-      });
-      await _db.insert(ins);
-    }
-    for (var i = 0; i < _iterations; i++) {
       final del = _db
           .queryBuilder()
           .table('users')
@@ -159,6 +155,8 @@ class KnexBench {
       await _db.delete(del);
     }
   });
+
+  Future<void> seedDeleteRows() => _seedDeleteRows(_db);
 }
 
 class KnexOtelBench {
@@ -220,13 +218,6 @@ class KnexOtelBench {
 
   Future<Duration> benchDelete() => _time(() async {
     for (var i = 0; i < _iterations; i++) {
-      final ins = _db.queryBuilder().table('users').insert({
-        'name': 'del_$i',
-        'age': 99,
-      });
-      await _db.insert(ins);
-    }
-    for (var i = 0; i < _iterations; i++) {
       final del = _db
           .queryBuilder()
           .table('users')
@@ -235,6 +226,8 @@ class KnexOtelBench {
       await _db.delete(del);
     }
   });
+
+  Future<void> seedDeleteRows() => _seedDeleteRows(_db);
 }
 
 Future<void> _seed(KnexSQLite db) async {
@@ -254,6 +247,16 @@ Future<void> _seed(KnexSQLite db) async {
   }
 }
 
+Future<void> _seedDeleteRows(KnexSQLite db) async {
+  for (var i = 0; i < _iterations; i++) {
+    final ins = db.queryBuilder().table('users').insert({
+      'name': 'del_$i',
+      'age': 99,
+    });
+    await db.insert(ins);
+  }
+}
+
 double _perOp(Duration duration) => duration.inMicroseconds / _iterations;
 
 String _formatMicros(Duration duration) => _perOp(duration).toStringAsFixed(2);
@@ -270,6 +273,7 @@ Future<void> main() async {
   final rawSelectMapped = await raw.benchSelectMapped();
   final rawInsert = await raw.benchInsert();
   final rawUpdate = await raw.benchUpdate();
+  raw.seedDeleteRows();
   final rawDelete = await raw.benchDelete();
   raw.tearDown();
 
@@ -278,6 +282,7 @@ Future<void> main() async {
   final knexSelect = await knex.benchSelect();
   final knexInsert = await knex.benchInsert();
   final knexUpdate = await knex.benchUpdate();
+  await knex.seedDeleteRows();
   final knexDelete = await knex.benchDelete();
   await knex.tearDown();
 
@@ -286,6 +291,7 @@ Future<void> main() async {
   final otelSelect = await otel.benchSelect();
   final otelInsert = await otel.benchInsert();
   final otelUpdate = await otel.benchUpdate();
+  await otel.seedDeleteRows();
   final otelDelete = await otel.benchDelete();
   await otel.tearDown();
 

--- a/benchmarks/bin/sqlite_live.dart
+++ b/benchmarks/bin/sqlite_live.dart
@@ -1,0 +1,325 @@
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:knex_dart_otel/knex_dart_otel.dart';
+import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
+import 'package:sqlite3/sqlite3.dart';
+
+const int _iterations = 10000;
+const int _seedRows = 100;
+
+typedef Bench = Future<void> Function();
+
+class CapturingHistogram extends APIHistogram<double> {
+  final List<(double value, Map<String, Object> attrs)> recordings = [];
+
+  CapturingHistogram(APIMeter meter)
+    : super('db.client.operation.duration', null, 's', true, meter);
+
+  @override
+  void record(double value, [Attributes? attributes]) {
+    recordings.add((value, {}));
+  }
+
+  @override
+  void recordWithMap(double value, Map<String, Object> attributeMap) {
+    recordings.add((value, Map<String, Object>.from(attributeMap)));
+  }
+}
+
+Future<Duration> _time(Bench fn) async {
+  final sw = Stopwatch()..start();
+  await fn();
+  sw.stop();
+  return sw.elapsed;
+}
+
+class RawBench {
+  late Database _db;
+
+  void setUp() {
+    _db = sqlite3.openInMemory();
+    _db.execute('''
+      CREATE TABLE users (
+        id   INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT    NOT NULL,
+        age  INTEGER NOT NULL
+      )
+    ''');
+    for (var i = 0; i < _seedRows; i++) {
+      _db.execute('INSERT INTO users (name, age) VALUES (?, ?)', [
+        'seed_$i',
+        20 + i % 40,
+      ]);
+    }
+  }
+
+  void tearDown() => _db.dispose();
+
+  Future<Duration> benchSelect() => _time(() async {
+    for (var i = 0; i < _iterations; i++) {
+      _db.select('SELECT * FROM users WHERE age > ?', [25]);
+    }
+  });
+
+  Future<Duration> benchSelectMapped() => _time(() async {
+    for (var i = 0; i < _iterations; i++) {
+      final result = _db.select('SELECT * FROM users WHERE age > ?', [25]);
+      final columns = result.columnNames;
+      for (final row in result.rows) {
+        final mapped = <String, dynamic>{};
+        for (var j = 0; j < columns.length; j++) {
+          mapped[columns[j]] = row[j];
+        }
+      }
+    }
+  });
+
+  Future<Duration> benchInsert() => _time(() async {
+    for (var i = 0; i < _iterations; i++) {
+      _db.execute('INSERT INTO users (name, age) VALUES (?, ?)', [
+        'bench_$i',
+        30,
+      ]);
+    }
+  });
+
+  Future<Duration> benchUpdate() => _time(() async {
+    for (var i = 0; i < _iterations; i++) {
+      _db.execute('UPDATE users SET age = ? WHERE name = ?', [
+        31,
+        'seed_${i % _seedRows}',
+      ]);
+    }
+  });
+
+  Future<Duration> benchDelete() => _time(() async {
+    for (var i = 0; i < _iterations; i++) {
+      _db.execute('INSERT INTO users (name, age) VALUES (?, ?)', [
+        'del_$i',
+        99,
+      ]);
+    }
+    for (var i = 0; i < _iterations; i++) {
+      _db.execute("DELETE FROM users WHERE name = 'del_$i'");
+    }
+  });
+}
+
+class KnexBench {
+  late KnexSQLite _db;
+
+  Future<void> setUp() async {
+    _db = await KnexSQLite.connect(filename: ':memory:');
+    await _seed(_db);
+  }
+
+  Future<void> tearDown() => _db.close();
+
+  Future<Duration> benchSelect() => _time(() async {
+    for (var i = 0; i < _iterations; i++) {
+      final qb = _db.queryBuilder().table('users').where('age', '>', 25);
+      await _db.select(qb);
+    }
+  });
+
+  Future<Duration> benchInsert() => _time(() async {
+    for (var i = 0; i < _iterations; i++) {
+      final qb = _db.queryBuilder().table('users').insert({
+        'name': 'bench_$i',
+        'age': 30,
+      });
+      await _db.insert(qb);
+    }
+  });
+
+  Future<Duration> benchUpdate() => _time(() async {
+    for (var i = 0; i < _iterations; i++) {
+      final qb = _db
+          .queryBuilder()
+          .table('users')
+          .where('name', '=', 'seed_${i % _seedRows}')
+          .update({'age': 31});
+      await _db.update(qb);
+    }
+  });
+
+  Future<Duration> benchDelete() => _time(() async {
+    for (var i = 0; i < _iterations; i++) {
+      final ins = _db.queryBuilder().table('users').insert({
+        'name': 'del_$i',
+        'age': 99,
+      });
+      await _db.insert(ins);
+    }
+    for (var i = 0; i < _iterations; i++) {
+      final del = _db
+          .queryBuilder()
+          .table('users')
+          .where('name', '=', 'del_$i')
+          .delete();
+      await _db.delete(del);
+    }
+  });
+}
+
+class KnexOtelBench {
+  late KnexSQLite _db;
+
+  Future<void> setUp() async {
+    OTelAPI.initialize(
+      endpoint: 'http://localhost:4317',
+      serviceName: 'knex-dart-sqlite-live-benchmark',
+      serviceVersion: '0.0.1',
+    );
+    final tracer = OTelAPI.tracer('knex_dart_sqlite_live_benchmark');
+    final histogram = CapturingHistogram(
+      OTelAPI.meterProvider().getMeter(name: 'knex_dart_sqlite_live_benchmark'),
+    );
+    _db = await KnexSQLite.connect(
+      filename: ':memory:',
+      interceptors: [
+        KnexOtelInterceptor(
+          tracer: tracer,
+          operationDurationHistogram: histogram,
+        ),
+      ],
+    );
+    await _seed(_db);
+  }
+
+  Future<void> tearDown() async {
+    await _db.close();
+  }
+
+  Future<Duration> benchSelect() => _time(() async {
+    for (var i = 0; i < _iterations; i++) {
+      final qb = _db.queryBuilder().table('users').where('age', '>', 25);
+      await _db.select(qb);
+    }
+  });
+
+  Future<Duration> benchInsert() => _time(() async {
+    for (var i = 0; i < _iterations; i++) {
+      final qb = _db.queryBuilder().table('users').insert({
+        'name': 'bench_$i',
+        'age': 30,
+      });
+      await _db.insert(qb);
+    }
+  });
+
+  Future<Duration> benchUpdate() => _time(() async {
+    for (var i = 0; i < _iterations; i++) {
+      final qb = _db
+          .queryBuilder()
+          .table('users')
+          .where('name', '=', 'seed_${i % _seedRows}')
+          .update({'age': 31});
+      await _db.update(qb);
+    }
+  });
+
+  Future<Duration> benchDelete() => _time(() async {
+    for (var i = 0; i < _iterations; i++) {
+      final ins = _db.queryBuilder().table('users').insert({
+        'name': 'del_$i',
+        'age': 99,
+      });
+      await _db.insert(ins);
+    }
+    for (var i = 0; i < _iterations; i++) {
+      final del = _db
+          .queryBuilder()
+          .table('users')
+          .where('name', '=', 'del_$i')
+          .delete();
+      await _db.delete(del);
+    }
+  });
+}
+
+Future<void> _seed(KnexSQLite db) async {
+  await db.rawSql('''
+      CREATE TABLE users (
+        id   INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT    NOT NULL,
+        age  INTEGER NOT NULL
+      )
+    ''');
+  for (var i = 0; i < _seedRows; i++) {
+    final qb = db.queryBuilder().table('users').insert({
+      'name': 'seed_$i',
+      'age': 20 + i % 40,
+    });
+    await db.insert(qb);
+  }
+}
+
+double _perOp(Duration duration) => duration.inMicroseconds / _iterations;
+
+String _formatMicros(Duration duration) => _perOp(duration).toStringAsFixed(2);
+
+String _formatRatio(Duration numerator, Duration denominator) {
+  return '${(numerator.inMicroseconds / denominator.inMicroseconds).toStringAsFixed(2)}x';
+}
+
+String _cell(String value, int width) => value.padLeft(width);
+
+Future<void> main() async {
+  final raw = RawBench()..setUp();
+  final rawSelect = await raw.benchSelect();
+  final rawSelectMapped = await raw.benchSelectMapped();
+  final rawInsert = await raw.benchInsert();
+  final rawUpdate = await raw.benchUpdate();
+  final rawDelete = await raw.benchDelete();
+  raw.tearDown();
+
+  final knex = KnexBench();
+  await knex.setUp();
+  final knexSelect = await knex.benchSelect();
+  final knexInsert = await knex.benchInsert();
+  final knexUpdate = await knex.benchUpdate();
+  final knexDelete = await knex.benchDelete();
+  await knex.tearDown();
+
+  final otel = KnexOtelBench();
+  await otel.setUp();
+  final otelSelect = await otel.benchSelect();
+  final otelInsert = await otel.benchInsert();
+  final otelUpdate = await otel.benchUpdate();
+  final otelDelete = await otel.benchDelete();
+  await otel.tearDown();
+
+  print('## SQLite Live Query Benchmark  (10 000 iterations)');
+  print('');
+  print(
+    '| Operation | raw sqlite3 | raw mapped | knex (µs/op) | knex+otel (µs/op) | knex/raw | knex/mapped | otel/knex |',
+  );
+  print(
+    '|-----------|-------------|------------|--------------|-------------------|----------|-------------|-----------|',
+  );
+
+  void printRow(
+    String operation,
+    Duration rawDuration,
+    Duration? rawMappedDuration,
+    Duration knexDuration,
+    Duration otelDuration,
+  ) {
+    final mappedDuration = rawMappedDuration ?? rawDuration;
+    print(
+      '| ${operation.padRight(9)} '
+      '| ${_cell(_formatMicros(rawDuration), 11)} '
+      '| ${_cell(rawMappedDuration == null ? '-' : _formatMicros(rawMappedDuration), 10)} '
+      '| ${_cell(_formatMicros(knexDuration), 12)} '
+      '| ${_cell(_formatMicros(otelDuration), 17)} '
+      '| ${_cell(_formatRatio(knexDuration, rawDuration), 8)} '
+      '| ${_cell(_formatRatio(knexDuration, mappedDuration), 11)} '
+      '| ${_cell(_formatRatio(otelDuration, knexDuration), 9)} |',
+    );
+  }
+
+  printRow('SELECT', rawSelect, rawSelectMapped, knexSelect, otelSelect);
+  printRow('INSERT', rawInsert, null, knexInsert, otelInsert);
+  printRow('UPDATE', rawUpdate, null, knexUpdate, otelUpdate);
+  printRow('DELETE', rawDelete, null, knexDelete, otelDelete);
+}

--- a/benchmarks/lib/benchmark_case.dart
+++ b/benchmarks/lib/benchmark_case.dart
@@ -1,0 +1,93 @@
+import 'package:knex_dart/knex_dart.dart';
+
+typedef BenchmarkBuild = BenchmarkOutput Function(KnexDialect dialect);
+
+enum BenchmarkMode { queryGeneration, schemaGeneration, rawGeneration }
+
+class BenchmarkOutput {
+  final String sql;
+  final List<dynamic> bindings;
+  final String method;
+  final int statementCount;
+
+  const BenchmarkOutput({
+    required this.sql,
+    required this.bindings,
+    required this.method,
+    this.statementCount = 1,
+  });
+
+  factory BenchmarkOutput.fromSqlString(SqlString sql) {
+    return BenchmarkOutput(
+      sql: sql.sql,
+      bindings: sql.bindings,
+      method: sql.method ?? 'raw',
+    );
+  }
+
+  factory BenchmarkOutput.fromSchema(List<Map<String, dynamic>> statements) {
+    return BenchmarkOutput(
+      sql: statements.map((statement) => statement['sql'] as String).join('; '),
+      bindings: [
+        for (final statement in statements)
+          ...(statement['bindings'] as List<dynamic>? ?? const []),
+      ],
+      method: 'schema',
+      statementCount: statements.length,
+    );
+  }
+}
+
+class BenchmarkCase {
+  final String id;
+  final String name;
+  final String category;
+  final BenchmarkMode mode;
+  final String complexity;
+  final List<String> features;
+  final Set<KnexDialect>? dialects;
+  final String? notes;
+  final BenchmarkBuild build;
+
+  const BenchmarkCase({
+    required this.id,
+    required this.name,
+    required this.category,
+    required this.mode,
+    required this.complexity,
+    required this.features,
+    required this.build,
+    this.dialects,
+    this.notes,
+  });
+
+  bool supports(KnexDialect dialect) =>
+      dialects == null || dialects!.contains(dialect);
+
+  Map<String, dynamic> toMetadataJson() {
+    return {
+      'id': id,
+      'name': name,
+      'category': category,
+      'mode': mode.name,
+      'complexity': complexity,
+      'features': features,
+      if (dialects != null) 'dialects': dialects!.map((d) => d.name).toList(),
+      if (notes != null) 'notes': notes,
+    };
+  }
+}
+
+const allBenchmarkDialects = [
+  KnexDialect.postgres,
+  KnexDialect.mysql,
+  KnexDialect.sqlite,
+  KnexDialect.mariadb,
+  KnexDialect.redshift,
+  KnexDialect.turso,
+  KnexDialect.d1,
+  KnexDialect.duckdb,
+  KnexDialect.snowflake,
+  KnexDialect.bigquery,
+  KnexDialect.mssql,
+];

--- a/benchmarks/lib/benchmark_case.dart
+++ b/benchmarks/lib/benchmark_case.dart
@@ -72,7 +72,8 @@ class BenchmarkCase {
       'mode': mode.name,
       'complexity': complexity,
       'features': features,
-      if (dialects != null) 'dialects': dialects!.map((d) => d.name).toList(),
+      if (dialects != null)
+        'dialects': (dialects!.map((d) => d.name).toList()..sort()),
       if (notes != null) 'notes': notes,
     };
   }

--- a/benchmarks/lib/benchmark_runner.dart
+++ b/benchmarks/lib/benchmark_runner.dart
@@ -122,8 +122,6 @@ class BenchmarkRunner {
   final List<BenchmarkCase> cases;
   final BenchmarkConfig config;
 
-  BenchmarkOutput? _lastOutput;
-
   BenchmarkRunner({required this.cases, required this.config});
 
   BenchmarkRun run() {
@@ -143,8 +141,8 @@ class BenchmarkRunner {
       }
     }
 
-    if (_lastOutput == null) {
-      throw StateError('benchmark produced no SQL');
+    if (results.isEmpty) {
+      throw StateError('benchmark run had no cases or dialects configured');
     }
 
     return BenchmarkRun(
@@ -167,7 +165,6 @@ class BenchmarkRunner {
   ) {
     try {
       final sample = benchmarkCase.build(dialect);
-      _lastOutput = sample;
 
       _time(benchmarkCase.build, dialect, config.warmupIterations);
       final elapsed = _time(benchmarkCase.build, dialect, config.iterations);
@@ -229,7 +226,7 @@ class BenchmarkRunner {
   Duration _time(BenchmarkBuild build, KnexDialect dialect, int iterations) {
     final sw = Stopwatch()..start();
     for (var i = 0; i < iterations; i++) {
-      _lastOutput = build(dialect);
+      build(dialect);
     }
     sw.stop();
     return sw.elapsed;

--- a/benchmarks/lib/benchmark_runner.dart
+++ b/benchmarks/lib/benchmark_runner.dart
@@ -1,0 +1,248 @@
+import 'dart:io';
+
+import 'package:knex_dart/knex_dart.dart';
+
+import 'benchmark_case.dart';
+
+class BenchmarkConfig {
+  final int iterations;
+  final int warmupIterations;
+  final List<KnexDialect> dialects;
+  final bool includeUnsupported;
+
+  const BenchmarkConfig({
+    required this.iterations,
+    required this.warmupIterations,
+    required this.dialects,
+    this.includeUnsupported = true,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'iterations': iterations,
+      'warmupIterations': warmupIterations,
+      'dialects': dialects.map((dialect) => dialect.name).toList(),
+      'includeUnsupported': includeUnsupported,
+    };
+  }
+}
+
+class BenchmarkRun {
+  final String runId;
+  final DateTime startedAt;
+  final BenchmarkConfig config;
+  final List<BenchmarkCaseResult> results;
+  final Map<String, dynamic> environment;
+
+  const BenchmarkRun({
+    required this.runId,
+    required this.startedAt,
+    required this.config,
+    required this.results,
+    required this.environment,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'runId': runId,
+      'startedAt': startedAt.toUtc().toIso8601String(),
+      'environment': environment,
+      'config': config.toJson(),
+      'results': results.map((result) => result.toJson()).toList(),
+    };
+  }
+}
+
+class BenchmarkCaseResult {
+  final String caseId;
+  final String caseName;
+  final String category;
+  final String mode;
+  final String complexity;
+  final List<String> features;
+  final String dialect;
+  final String status;
+  final double? microsecondsPerOp;
+  final int iterations;
+  final int warmupIterations;
+  final int? sqlLength;
+  final int? bindingCount;
+  final int? statementCount;
+  final String? method;
+  final String? sqlSample;
+  final String? errorType;
+  final String? error;
+
+  const BenchmarkCaseResult({
+    required this.caseId,
+    required this.caseName,
+    required this.category,
+    required this.mode,
+    required this.complexity,
+    required this.features,
+    required this.dialect,
+    required this.status,
+    required this.iterations,
+    required this.warmupIterations,
+    this.microsecondsPerOp,
+    this.sqlLength,
+    this.bindingCount,
+    this.statementCount,
+    this.method,
+    this.sqlSample,
+    this.errorType,
+    this.error,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'caseId': caseId,
+      'caseName': caseName,
+      'category': category,
+      'mode': mode,
+      'complexity': complexity,
+      'features': features,
+      'dialect': dialect,
+      'status': status,
+      'iterations': iterations,
+      'warmupIterations': warmupIterations,
+      if (microsecondsPerOp != null) 'microsecondsPerOp': microsecondsPerOp,
+      if (sqlLength != null) 'sqlLength': sqlLength,
+      if (bindingCount != null) 'bindingCount': bindingCount,
+      if (statementCount != null) 'statementCount': statementCount,
+      if (method != null) 'method': method,
+      if (sqlSample != null) 'sqlSample': sqlSample,
+      if (errorType != null) 'errorType': errorType,
+      if (error != null) 'error': error,
+    };
+  }
+}
+
+class BenchmarkRunner {
+  final List<BenchmarkCase> cases;
+  final BenchmarkConfig config;
+
+  BenchmarkOutput? _lastOutput;
+
+  BenchmarkRunner({required this.cases, required this.config});
+
+  BenchmarkRun run() {
+    final startedAt = DateTime.now().toUtc();
+    final results = <BenchmarkCaseResult>[];
+
+    for (final benchmarkCase in cases) {
+      for (final dialect in config.dialects) {
+        if (!benchmarkCase.supports(dialect)) {
+          if (config.includeUnsupported) {
+            results.add(_unsupportedResult(benchmarkCase, dialect));
+          }
+          continue;
+        }
+
+        results.add(_runCase(benchmarkCase, dialect));
+      }
+    }
+
+    if (_lastOutput == null) {
+      throw StateError('benchmark produced no SQL');
+    }
+
+    return BenchmarkRun(
+      runId: startedAt.toIso8601String().replaceAll(':', '-'),
+      startedAt: startedAt,
+      config: config,
+      results: results,
+      environment: {
+        'dartVersion': Platform.version,
+        'operatingSystem': Platform.operatingSystem,
+        'operatingSystemVersion': Platform.operatingSystemVersion,
+        'numberOfProcessors': Platform.numberOfProcessors,
+      },
+    );
+  }
+
+  BenchmarkCaseResult _runCase(
+    BenchmarkCase benchmarkCase,
+    KnexDialect dialect,
+  ) {
+    try {
+      final sample = benchmarkCase.build(dialect);
+      _lastOutput = sample;
+
+      _time(benchmarkCase.build, dialect, config.warmupIterations);
+      final elapsed = _time(benchmarkCase.build, dialect, config.iterations);
+
+      return BenchmarkCaseResult(
+        caseId: benchmarkCase.id,
+        caseName: benchmarkCase.name,
+        category: benchmarkCase.category,
+        mode: benchmarkCase.mode.name,
+        complexity: benchmarkCase.complexity,
+        features: benchmarkCase.features,
+        dialect: dialect.name,
+        status: 'ok',
+        microsecondsPerOp: elapsed.inMicroseconds / config.iterations,
+        iterations: config.iterations,
+        warmupIterations: config.warmupIterations,
+        sqlLength: sample.sql.length,
+        bindingCount: sample.bindings.length,
+        statementCount: sample.statementCount,
+        method: sample.method,
+        sqlSample: _sampleSql(sample.sql),
+      );
+    } catch (error, stackTrace) {
+      return BenchmarkCaseResult(
+        caseId: benchmarkCase.id,
+        caseName: benchmarkCase.name,
+        category: benchmarkCase.category,
+        mode: benchmarkCase.mode.name,
+        complexity: benchmarkCase.complexity,
+        features: benchmarkCase.features,
+        dialect: dialect.name,
+        status: 'error',
+        iterations: config.iterations,
+        warmupIterations: config.warmupIterations,
+        errorType: error.runtimeType.toString(),
+        error: '$error\n${_firstStackLine(stackTrace)}',
+      );
+    }
+  }
+
+  BenchmarkCaseResult _unsupportedResult(
+    BenchmarkCase benchmarkCase,
+    KnexDialect dialect,
+  ) {
+    return BenchmarkCaseResult(
+      caseId: benchmarkCase.id,
+      caseName: benchmarkCase.name,
+      category: benchmarkCase.category,
+      mode: benchmarkCase.mode.name,
+      complexity: benchmarkCase.complexity,
+      features: benchmarkCase.features,
+      dialect: dialect.name,
+      status: 'unsupported_expected',
+      iterations: config.iterations,
+      warmupIterations: config.warmupIterations,
+    );
+  }
+
+  Duration _time(BenchmarkBuild build, KnexDialect dialect, int iterations) {
+    final sw = Stopwatch()..start();
+    for (var i = 0; i < iterations; i++) {
+      _lastOutput = build(dialect);
+    }
+    sw.stop();
+    return sw.elapsed;
+  }
+
+  String _sampleSql(String sql) {
+    const maxLength = 240;
+    if (sql.length <= maxLength) return sql;
+    return '${sql.substring(0, maxLength)}...';
+  }
+
+  String _firstStackLine(StackTrace stackTrace) {
+    final lines = stackTrace.toString().split('\n');
+    return lines.isEmpty ? '' : lines.first;
+  }
+}

--- a/benchmarks/lib/dialect_cases.dart
+++ b/benchmarks/lib/dialect_cases.dart
@@ -1,0 +1,457 @@
+import 'package:knex_dart/knex_dart.dart';
+
+import 'benchmark_case.dart';
+
+final sqlGenerationCases = <BenchmarkCase>[
+  BenchmarkCase(
+    id: 'select_simple',
+    name: 'SELECT simple',
+    category: 'select',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'basic',
+    features: ['select', 'projection'],
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(
+        dialect,
+      ).from('users').select(['id', 'name', 'email']).toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'select_complex',
+    name: 'SELECT complex',
+    category: 'select',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'medium',
+    features: ['select', 'where', 'order_by', 'limit', 'offset'],
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(dialect)
+          .from('users')
+          .select(['*'])
+          .where('age', '>', 25)
+          .where('active', '=', true)
+          .orderBy('name', 'asc')
+          .limit(50)
+          .offset(100)
+          .toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'insert_single',
+    name: 'INSERT single',
+    category: 'mutation',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'basic',
+    features: ['insert'],
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(dialect).from('users').insert({
+        'name': 'Alice',
+        'age': 30,
+        'email': 'a@example.com',
+      }).toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'insert_batch',
+    name: 'INSERT batch',
+    category: 'mutation',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'medium',
+    features: ['insert', 'batch_values'],
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(dialect).from('users').insert([
+        {'name': 'Alice', 'age': 30, 'email': 'a@example.com'},
+        {'name': 'Bob', 'age': 31, 'email': 'b@example.com'},
+        {'name': 'Cara', 'age': 32, 'email': 'c@example.com'},
+      ]).toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'update_where',
+    name: 'UPDATE where',
+    category: 'mutation',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'basic',
+    features: ['update', 'where'],
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(dialect).from('users').where('id', '=', 1).update({
+        'name': 'Bob',
+        'age': 31,
+      }).toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'delete_where',
+    name: 'DELETE where',
+    category: 'mutation',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'basic',
+    features: ['delete', 'where'],
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(
+        dialect,
+      ).from('users').where('id', '=', 1).delete().toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'where_wrapped_between_null',
+    name: 'WHERE wrapped/between/null',
+    category: 'where',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'medium',
+    features: ['where_wrapped', 'where_between', 'where_null'],
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(dialect)
+          .from('users')
+          .select(['id'])
+          .whereWrapped((qb) {
+            qb.where('age', '>=', 18).orWhere('verified', '=', true);
+          })
+          .whereBetween('created_at', ['2026-01-01', '2026-12-31'])
+          .whereNull('deleted_at')
+          .toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'where_exists',
+    name: 'WHERE exists',
+    category: 'where',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'medium',
+    features: ['where_exists', 'where_raw'],
+    build: (dialect) {
+      final client = KnexQuery.forDialect(dialect);
+      return BenchmarkOutput.fromSqlString(
+        client.from('users').whereExists((qb) {
+          qb
+              .from('orders')
+              .select(['id'])
+              .where(
+                client.queryBuilder().client.raw('orders.user_id = users.id'),
+              );
+        }).toSQL(),
+      );
+    },
+  ),
+  BenchmarkCase(
+    id: 'aggregate_group_having',
+    name: 'Aggregate group/having',
+    category: 'aggregate',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'medium',
+    features: ['sum', 'count', 'group_by', 'having'],
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(dialect)
+          .from('orders')
+          .select(['customer_id'])
+          .sum('amount as total')
+          .count('id as count')
+          .groupBy('customer_id')
+          .having('total', '>', 1000)
+          .having('count', '>=', 5)
+          .toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'join_advanced',
+    name: 'JOIN advanced',
+    category: 'join',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'medium',
+    features: ['join', 'join_callback', 'where'],
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(dialect)
+          .from('users')
+          .select(['users.*', 'orders.total'])
+          .join('orders', (JoinClause join) {
+            join
+                .on('users.id', '=', 'orders.user_id')
+                .andOn('orders.status', '=', 'users.status');
+          })
+          .where('orders.total', '>', 100)
+          .toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'subquery_where_in',
+    name: 'Subquery whereIn',
+    category: 'subquery',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'medium',
+    features: ['subquery', 'where_in'],
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(dialect).from('users').whereIn('id', (
+        QueryBuilder qb,
+      ) {
+        qb.from('orders').select(['user_id']).where('total', '>', 500);
+      }).toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'cte_multiple',
+    name: 'CTE multiple',
+    category: 'cte',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'complex',
+    features: ['cte', 'join', 'subquery'],
+    build: (dialect) {
+      final client = KnexQuery.forDialect(dialect);
+      final sales = client
+          .queryBuilder()
+          .table('orders')
+          .select(['*'])
+          .where('status', '=', 'completed');
+      final returns = client.queryBuilder().table('refunds').select(['*']);
+      return BenchmarkOutput.fromSqlString(
+        client
+            .queryBuilder()
+            .withQuery('sales', sales)
+            .withQuery('returns', returns)
+            .select(['*'])
+            .from('sales')
+            .join('returns', 'sales.id', 'returns.order_id')
+            .toSQL(),
+      );
+    },
+  ),
+  BenchmarkCase(
+    id: 'cte_recursive',
+    name: 'CTE recursive',
+    category: 'cte',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'complex',
+    features: ['recursive_cte', 'union', 'join'],
+    build: (dialect) {
+      final client = KnexQuery.forDialect(dialect);
+      final recursive = client
+          .queryBuilder()
+          .table('nodes')
+          .select(['*'])
+          .where('parent_id', '=', null)
+          .union([
+            client
+                .queryBuilder()
+                .table('nodes as n')
+                .select(['n.*'])
+                .join('tree as t', 'n.parent_id', 't.id'),
+          ]);
+      return BenchmarkOutput.fromSqlString(
+        client
+            .queryBuilder()
+            .withRecursive('tree', recursive)
+            .select(['*'])
+            .from('tree')
+            .toSQL(),
+      );
+    },
+  ),
+  BenchmarkCase(
+    id: 'union_intersect_except',
+    name: 'Union/intersect/except',
+    category: 'set',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'complex',
+    features: ['union', 'intersect', 'except'],
+    build: (dialect) {
+      final client = KnexQuery.forDialect(dialect);
+      final active = client
+          .queryBuilder()
+          .table('users')
+          .select(['id'])
+          .where('active', '=', true);
+      final paid = client
+          .queryBuilder()
+          .table('orders')
+          .select(['user_id'])
+          .where('total', '>', 100);
+      final banned = client.queryBuilder().table('bans').select(['user_id']);
+      return BenchmarkOutput.fromSqlString(
+        active.union([paid]).except([banned]).toSQL(),
+      );
+    },
+  ),
+  BenchmarkCase(
+    id: 'window_row_number',
+    name: 'Window rowNumber',
+    category: 'window',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'medium',
+    features: ['window_function', 'row_number'],
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(dialect)
+          .from('employees')
+          .select(['name', 'department', 'salary'])
+          .rowNumber('rn', 'salary', 'department')
+          .toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'window_rank_dense_rank',
+    name: 'Window rank/denseRank',
+    category: 'window',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'complex',
+    features: ['window_function', 'rank', 'dense_rank'],
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(dialect)
+          .from('employees')
+          .select(['name', 'department', 'salary'])
+          .rank('ranked', 'salary', 'department')
+          .denseRank('dense_ranked', 'salary', 'department')
+          .toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'on_conflict_merge',
+    name: 'onConflict merge',
+    category: 'insert',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'medium',
+    features: ['insert', 'on_conflict', 'merge'],
+    dialects: {
+      KnexDialect.postgres,
+      KnexDialect.mysql,
+      KnexDialect.sqlite,
+      KnexDialect.mariadb,
+    },
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(dialect)
+          .from('users')
+          .insert({'email': 'a@b.com', 'name': 'Alice'})
+          .onConflict('email')
+          .merge()
+          .toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'returning_insert',
+    name: 'INSERT returning',
+    category: 'insert',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'medium',
+    features: ['insert', 'returning'],
+    dialects: {KnexDialect.postgres, KnexDialect.mssql},
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(dialect)
+          .from('users')
+          .insert({'email': 'a@b.com', 'name': 'Alice'})
+          .returning(['id', 'name'])
+          .toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'locking_skip_locked',
+    name: 'Locking skipLocked',
+    category: 'locking',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'medium',
+    features: ['for_update', 'skip_locked'],
+    dialects: {
+      KnexDialect.postgres,
+      KnexDialect.mysql,
+      KnexDialect.mariadb,
+      KnexDialect.redshift,
+    },
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(
+        dialect,
+      ).from('users').select(['*']).forUpdate().skipLocked().toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'from_raw',
+    name: 'fromRaw',
+    category: 'raw',
+    mode: BenchmarkMode.queryGeneration,
+    complexity: 'medium',
+    features: ['from_raw', 'raw_bindings'],
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(dialect)
+          .queryBuilder()
+          .fromRaw('(select * from users where active = ?) as active_users', [
+            true,
+          ])
+          .select(['id', 'email'])
+          .where('email', 'like', '%@example.com')
+          .toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'raw_standalone',
+    name: 'Raw standalone',
+    category: 'raw',
+    mode: BenchmarkMode.rawGeneration,
+    complexity: 'basic',
+    features: ['raw', 'identifier_bindings', 'value_bindings'],
+    build: (dialect) => BenchmarkOutput.fromSqlString(
+      KnexQuery.forDialect(dialect).queryBuilder().client.raw(
+        'select ?? from ?? where ?? = ?',
+        ['id', 'users', 'active', true],
+      ).toSQL(),
+    ),
+  ),
+  BenchmarkCase(
+    id: 'schema_create_table',
+    name: 'Schema createTable',
+    category: 'schema',
+    mode: BenchmarkMode.schemaGeneration,
+    complexity: 'medium',
+    features: ['schema', 'create_table', 'column_types', 'timestamps'],
+    build: (dialect) {
+      final schema = KnexQuery.forDialect(dialect).schemaBuilder();
+      schema.createTable('users', (table) {
+        table.increments('id');
+        table.string('name');
+        table.string('email', 255).unique();
+        table.integer('age');
+        table.boolean('active').defaultTo(true);
+        table.timestamps(true, true);
+      });
+      return BenchmarkOutput.fromSchema(schema.toSQL());
+    },
+  ),
+  BenchmarkCase(
+    id: 'schema_alter_table',
+    name: 'Schema alterTable',
+    category: 'schema',
+    mode: BenchmarkMode.schemaGeneration,
+    complexity: 'medium',
+    features: ['schema', 'alter_table', 'add_column', 'drop_column'],
+    build: (dialect) {
+      final schema = KnexQuery.forDialect(dialect).schemaBuilder();
+      schema.alterTable('users', (table) {
+        table.string('phone');
+        table.dropColumn('legacy_code');
+      });
+      return BenchmarkOutput.fromSchema(schema.toSQL());
+    },
+  ),
+];
+
+final matrixCoverageMetadata = <Map<String, dynamic>>[
+  for (final benchmarkCase in sqlGenerationCases)
+    benchmarkCase.toMetadataJson(),
+  {
+    'id': 'json_public_api_gap',
+    'name': 'JSON where helpers',
+    'category': 'json',
+    'mode': BenchmarkMode.queryGeneration.name,
+    'complexity': 'medium',
+    'features': ['where_json_path', 'where_json_superset', 'where_json_subset'],
+    'status': 'not_benchmarked',
+    'notes':
+        'The JSON extension is implemented under src/ and is not exported '
+        'by package:knex_dart/knex_dart.dart yet.',
+  },
+  {
+    'id': 'live_driver_matrix_gap',
+    'name': 'Live driver execution matrix',
+    'category': 'live',
+    'mode': 'live_execution',
+    'complexity': 'system',
+    'features': ['driver_execution', 'network', 'pool', 'transactions'],
+    'status': 'planned',
+    'notes':
+        'This first matrix covers generation cost. Live driver execution '
+        'needs service orchestration per database.',
+  },
+];

--- a/benchmarks/lib/reporters.dart
+++ b/benchmarks/lib/reporters.dart
@@ -1,0 +1,252 @@
+import 'dart:convert';
+
+import 'benchmark_runner.dart';
+
+String benchmarkRunToJson(BenchmarkRun run) {
+  return const JsonEncoder.withIndent('  ').convert(run.toJson());
+}
+
+String benchmarkRunToMarkdown(BenchmarkRun run) {
+  final buffer = StringBuffer()
+    ..writeln('## Knex Dart Query-Building Benchmark Matrix')
+    ..writeln()
+    ..writeln(
+      'Iterations: ${run.config.iterations}, '
+      'warmup: ${run.config.warmupIterations}',
+    )
+    ..writeln()
+    ..writeln('### API Cost Summary')
+    ..writeln()
+    ..writeln(
+      '| Operation | Category | Avg us/op | vs SELECT simple | Min us/op | Max us/op | Dialects | Status |',
+    )
+    ..writeln(
+      '|-----------|----------|-----------|------------------|-----------|-----------|----------|--------|',
+    );
+
+  final summaries = _summaries(run.results);
+  final baseline = _baseline(summaries);
+  for (final summary in summaries) {
+    buffer.writeln(
+      '| ${summary.caseName} '
+      '| ${summary.category} '
+      '| ${summary.average.toStringAsFixed(2)} '
+      '| ${_formatRatio(summary.average, baseline)} '
+      '| ${summary.minimum.toStringAsFixed(2)} '
+      '| ${summary.maximum.toStringAsFixed(2)} '
+      '| ${summary.measuredDialects} '
+      '| ${summary.status} |',
+    );
+  }
+
+  buffer
+    ..writeln()
+    ..writeln('### Category Summary')
+    ..writeln()
+    ..writeln('| Category | Cases | Avg us/op | Max case | Max avg us/op |')
+    ..writeln('|----------|-------|-----------|----------|---------------|');
+
+  for (final category in _categorySummaries(summaries)) {
+    buffer.writeln(
+      '| ${category.category} '
+      '| ${category.caseCount} '
+      '| ${category.average.toStringAsFixed(2)} '
+      '| ${category.maxCaseName} '
+      '| ${category.maxAverage.toStringAsFixed(2)} |',
+    );
+  }
+
+  buffer
+    ..writeln()
+    ..writeln('### Full Matrix')
+    ..writeln()
+    ..writeln(
+      '| Category | Operation | Dialect | Status | us/op | Bindings | SQL len | Statements |',
+    )
+    ..writeln(
+      '|----------|-----------|---------|--------|-------|----------|---------|------------|',
+    );
+
+  for (final result in run.results) {
+    buffer.writeln(
+      '| ${result.category} '
+      '| ${result.caseName} '
+      '| ${result.dialect} '
+      '| ${result.status} '
+      '| ${_formatMicros(result.microsecondsPerOp)} '
+      '| ${result.bindingCount ?? ''} '
+      '| ${result.sqlLength ?? ''} '
+      '| ${result.statementCount ?? ''} |',
+    );
+  }
+
+  final errors = run.results.where((result) => result.status == 'error');
+  if (errors.isNotEmpty) {
+    buffer
+      ..writeln()
+      ..writeln('### Errors')
+      ..writeln()
+      ..writeln('| Operation | Dialect | Error |')
+      ..writeln('|-----------|---------|-------|');
+    for (final result in errors) {
+      buffer.writeln(
+        '| ${result.caseName} '
+        '| ${result.dialect} '
+        '| ${_escapeCell(result.errorType ?? result.error ?? 'error')} |',
+      );
+    }
+  }
+
+  return buffer.toString();
+}
+
+List<_OperationSummary> _summaries(List<BenchmarkCaseResult> results) {
+  final byCase = <String, List<BenchmarkCaseResult>>{};
+  for (final result in results) {
+    byCase.putIfAbsent(result.caseId, () => []).add(result);
+  }
+
+  return [for (final entries in byCase.values) _summarize(entries)];
+}
+
+double? _baseline(List<_OperationSummary> summaries) {
+  for (final summary in summaries) {
+    if (summary.caseName == 'SELECT simple' && summary.average > 0) {
+      return summary.average;
+    }
+  }
+  return null;
+}
+
+List<_CategorySummary> _categorySummaries(List<_OperationSummary> summaries) {
+  final byCategory = <String, List<_OperationSummary>>{};
+  for (final summary in summaries.where((summary) => summary.average > 0)) {
+    byCategory.putIfAbsent(summary.category, () => []).add(summary);
+  }
+
+  final categorySummaries = <_CategorySummary>[];
+  for (final entry in byCategory.entries) {
+    var total = 0.0;
+    var max = entry.value.first;
+    for (final summary in entry.value) {
+      total += summary.average;
+      if (summary.average > max.average) {
+        max = summary;
+      }
+    }
+
+    categorySummaries.add(
+      _CategorySummary(
+        category: entry.key,
+        caseCount: entry.value.length,
+        average: total / entry.value.length,
+        maxCaseName: max.caseName,
+        maxAverage: max.average,
+      ),
+    );
+  }
+
+  categorySummaries.sort((a, b) => b.average.compareTo(a.average));
+  return categorySummaries;
+}
+
+_OperationSummary _summarize(List<BenchmarkCaseResult> entries) {
+  final measured = entries
+      .where((entry) => entry.status == 'ok' && entry.microsecondsPerOp != null)
+      .toList();
+  if (measured.isEmpty) {
+    final statuses = entries.map((entry) => entry.status).toSet().join(',');
+    return _OperationSummary(
+      caseName: entries.first.caseName,
+      category: entries.first.category,
+      average: 0,
+      minimum: 0,
+      maximum: 0,
+      measuredDialects: 0,
+      status: statuses,
+    );
+  }
+
+  var total = 0.0;
+  var minimum = measured.first.microsecondsPerOp!;
+  var maximum = measured.first.microsecondsPerOp!;
+  for (final entry in measured.skip(1)) {
+    final value = entry.microsecondsPerOp!;
+    if (value < minimum) minimum = value;
+    if (value > maximum) maximum = value;
+  }
+  for (final entry in measured) {
+    total += entry.microsecondsPerOp!;
+  }
+  final average = total / measured.length;
+
+  final unsupportedCount = entries
+      .where((entry) => entry.status == 'unsupported_expected')
+      .length;
+  final errorCount = entries.where((entry) => entry.status == 'error').length;
+  final status = [
+    '${measured.length} ok',
+    if (unsupportedCount > 0) '$unsupportedCount unsupported',
+    if (errorCount > 0) '$errorCount error',
+  ].join(', ');
+
+  return _OperationSummary(
+    caseName: entries.first.caseName,
+    category: entries.first.category,
+    average: average,
+    minimum: minimum,
+    maximum: maximum,
+    measuredDialects: measured.length,
+    status: status,
+  );
+}
+
+String _formatMicros(double? value) {
+  if (value == null) return '';
+  return value.toStringAsFixed(2);
+}
+
+String _formatRatio(double value, double? baseline) {
+  if (baseline == null || baseline == 0 || value == 0) return '';
+  return '${(value / baseline).toStringAsFixed(2)}x';
+}
+
+String _escapeCell(String value) {
+  return value.replaceAll('|', r'\|').replaceAll('\n', ' ');
+}
+
+class _OperationSummary {
+  final String caseName;
+  final String category;
+  final double average;
+  final double minimum;
+  final double maximum;
+  final int measuredDialects;
+  final String status;
+
+  const _OperationSummary({
+    required this.caseName,
+    required this.category,
+    required this.average,
+    required this.minimum,
+    required this.maximum,
+    required this.measuredDialects,
+    required this.status,
+  });
+}
+
+class _CategorySummary {
+  final String category;
+  final int caseCount;
+  final double average;
+  final String maxCaseName;
+  final double maxAverage;
+
+  const _CategorySummary({
+    required this.category,
+    required this.caseCount,
+    required this.average,
+    required this.maxCaseName,
+    required this.maxAverage,
+  });
+}

--- a/benchmarks/lib/reporters.dart
+++ b/benchmarks/lib/reporters.dart
@@ -111,7 +111,7 @@ List<_OperationSummary> _summaries(List<BenchmarkCaseResult> results) {
 
 double? _baseline(List<_OperationSummary> summaries) {
   for (final summary in summaries) {
-    if (summary.caseName == 'SELECT simple' && summary.average > 0) {
+    if (summary.caseId == 'select_simple' && summary.average > 0) {
       return summary.average;
     }
   }
@@ -157,6 +157,7 @@ _OperationSummary _summarize(List<BenchmarkCaseResult> entries) {
   if (measured.isEmpty) {
     final statuses = entries.map((entry) => entry.status).toSet().join(',');
     return _OperationSummary(
+      caseId: entries.first.caseId,
       caseName: entries.first.caseName,
       category: entries.first.category,
       average: 0,
@@ -191,6 +192,7 @@ _OperationSummary _summarize(List<BenchmarkCaseResult> entries) {
   ].join(', ');
 
   return _OperationSummary(
+    caseId: entries.first.caseId,
     caseName: entries.first.caseName,
     category: entries.first.category,
     average: average,
@@ -216,6 +218,7 @@ String _escapeCell(String value) {
 }
 
 class _OperationSummary {
+  final String caseId;
   final String caseName;
   final String category;
   final double average;
@@ -225,6 +228,7 @@ class _OperationSummary {
   final String status;
 
   const _OperationSummary({
+    required this.caseId,
     required this.caseName,
     required this.category,
     required this.average,

--- a/benchmarks/matrix/operations.json
+++ b/benchmarks/matrix/operations.json
@@ -1,0 +1,46 @@
+{
+  "version": 1,
+  "purpose": "Benchmark coverage map for knex_dart SQL generation and future live driver execution.",
+  "dialects": [
+    "postgres",
+    "mysql",
+    "sqlite",
+    "mariadb",
+    "redshift",
+    "turso",
+    "d1",
+    "duckdb",
+    "snowflake",
+    "bigquery",
+    "mssql"
+  ],
+  "coveredCategories": [
+    "select",
+    "mutation",
+    "where",
+    "aggregate",
+    "join",
+    "subquery",
+    "cte",
+    "set",
+    "window",
+    "insert",
+    "locking",
+    "raw",
+    "schema"
+  ],
+  "trackedGaps": [
+    {
+      "id": "json_public_api_gap",
+      "category": "json",
+      "status": "not_benchmarked",
+      "reason": "JSON helpers are currently implemented as an internal extension and are not exported by package:knex_dart/knex_dart.dart."
+    },
+    {
+      "id": "live_driver_matrix_gap",
+      "category": "live",
+      "status": "planned",
+      "reason": "Live driver execution needs per-database orchestration and should be tracked separately from pure SQL generation."
+    }
+  ]
+}

--- a/benchmarks/pubspec.yaml
+++ b/benchmarks/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  knex_dart: ^1.2.0
-  knex_dart_sqlite: ^0.2.0
+  knex_dart: ^1.2.1
+  knex_dart_sqlite: ^0.2.1
   knex_dart_otel: ^0.1.0
   dartastic_opentelemetry_api: ^0.9.0
   sqlite3: any

--- a/benchmarks/pubspec.yaml
+++ b/benchmarks/pubspec.yaml
@@ -13,4 +13,4 @@ dependencies:
   knex_dart_sqlite: ^0.2.1
   knex_dart_otel: ^0.1.0
   dartastic_opentelemetry_api: ^0.9.0
-  sqlite3: any
+  sqlite3: ^2.4.0

--- a/benchmarks/pubspec.yaml
+++ b/benchmarks/pubspec.yaml
@@ -1,0 +1,16 @@
+name: knex_dart_benchmark
+description: Benchmarks for knex_dart SQL generation and live SQLite query execution.
+publish_to: none
+version: 0.0.1
+
+environment:
+  sdk: ^3.10.0
+
+resolution: workspace
+
+dependencies:
+  knex_dart: ^1.2.0
+  knex_dart_sqlite: ^0.2.0
+  knex_dart_otel: ^0.1.0
+  dartastic_opentelemetry_api: ^0.9.0
+  sqlite3: any

--- a/drivers/knex_dart_sqlite/CHANGELOG.md
+++ b/drivers/knex_dart_sqlite/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.2.1
+
+- Reduced wrapper overhead by reusing compiled SQL through the interceptor
+  pipeline instead of compiling the same query twice.
+- Removed redundant async wrappers in low-level query dispatch while preserving
+  public `Future` semantics and error propagation.
+- Optimized native SQLite row mapping by reading `ResultSet` column names and
+  rows directly.
+- No query result shape, binding behavior, or SQL execution semantics changed.
+
 ## 0.2.0
 
 - Added web/WASM SQLite support with conditional web client loading.

--- a/drivers/knex_dart_sqlite/lib/src/knex_sqlite.dart
+++ b/drivers/knex_dart_sqlite/lib/src/knex_sqlite.dart
@@ -9,7 +9,7 @@ class KnexSQLite {
   final KnexInterceptorPipeline _pipeline;
 
   KnexSQLite._(this._client, {required KnexInterceptorPipeline pipeline})
-      : _pipeline = pipeline;
+    : _pipeline = pipeline;
 
   /// Create a Knex instance connected to SQLite.
   ///
@@ -42,24 +42,26 @@ class KnexSQLite {
   }
 
   /// Executes a SELECT-style query and returns rows.
-  Future<List<Map<String, dynamic>>> select(QueryBuilder query) =>
-      _pipeline.run(query, () => _client.select(query));
+  Future<List<Map<String, dynamic>>> select(QueryBuilder query) {
+    final compiled = query.toSQL();
+    return _pipeline.runCompiled(query, compiled, _client.executeCompiled);
+  }
 
   /// Executes any compiled query and returns rows/result payload.
   Future<List<Map<String, dynamic>>> execute(QueryBuilder query) =>
-      _pipeline.run(query, () => _client.execute(query));
+      select(query);
 
   /// Executes an INSERT query.
   Future<List<Map<String, dynamic>>> insert(QueryBuilder query) =>
-      _pipeline.run(query, () => _client.insert(query));
+      select(query);
 
   /// Executes an UPDATE query.
   Future<List<Map<String, dynamic>>> update(QueryBuilder query) =>
-      _pipeline.run(query, () => _client.update(query));
+      select(query);
 
   /// Executes a DELETE query.
   Future<List<Map<String, dynamic>>> delete(QueryBuilder query) =>
-      _pipeline.run(query, () => _client.delete(query));
+      select(query);
 
   /// Creates a raw SQL fragment for use inside QueryBuilder clauses.
   Raw raw(String sql, [List<dynamic>? bindings]) => _client.raw(sql, bindings);
@@ -68,15 +70,10 @@ class KnexSQLite {
   Future<List<Map<String, dynamic>>> rawSql(
     String sql, [
     List<dynamic>? bindings,
-  ]) =>
-      _pipeline.runRaw(
-        sql,
-        bindings ?? const [],
-        () async {
-          final result = await _client.rawQuery(sql, bindings ?? []);
-          return result is List<Map<String, dynamic>> ? result : [];
-        },
-      );
+  ]) => _pipeline.runRaw(sql, bindings ?? const [], () async {
+    final result = await _client.rawQuery(sql, bindings ?? []);
+    return result is List<Map<String, dynamic>> ? result : [];
+  });
 
   /// Creates a new query builder bound to this SQLite client.
   QueryBuilder queryBuilder() => _client.queryBuilder();
@@ -109,13 +106,14 @@ class KnexSQLite {
   }
 
   /// Streams query results row by row.
-  Stream<Map<String, dynamic>> streamQuery(QueryBuilder query) =>
-      _pipeline.runStream(query, () {
-        final compiled = query.toSQL();
-        // SQLiteClient.streamQuery uses the low-level (connection, sql, bindings)
-        // signature; connection is ignored — SQLite is single-connection.
-        return _client.streamQuery(null, compiled.sql, compiled.bindings);
-      });
+  Stream<Map<String, dynamic>> streamQuery(
+    QueryBuilder query,
+  ) => _pipeline.runStream(query, () {
+    final compiled = query.toSQL();
+    // SQLiteClient.streamQuery uses the low-level (connection, sql, bindings)
+    // signature; connection is ignored — SQLite is single-connection.
+    return _client.streamQuery(null, compiled.sql, compiled.bindings);
+  });
 
   /// Run a transaction.
   Future<T> trx<T>(Future<T> Function(KnexSQLiteTransaction tx) callback) =>
@@ -154,35 +152,40 @@ class KnexSQLiteTransaction extends KnexTransaction {
   }
 
   @override
-  Future<List<Map<String, dynamic>>> select(QueryBuilder query) =>
-      _pipeline.run(query, () => _client.select(query), txId: txId);
+  Future<List<Map<String, dynamic>>> select(QueryBuilder query) {
+    final compiled = query.toSQL();
+    return _pipeline.runCompiled(
+      query,
+      compiled,
+      _client.executeCompiled,
+      txId: txId,
+    );
+  }
 
   @override
   Future<List<Map<String, dynamic>>> execute(QueryBuilder query) =>
-      _pipeline.run(query, () => _client.execute(query), txId: txId);
+      select(query);
 
   @override
   Future<List<Map<String, dynamic>>> insert(QueryBuilder query) =>
-      _pipeline.run(query, () => _client.insert(query), txId: txId);
+      select(query);
 
   @override
   Future<List<Map<String, dynamic>>> update(QueryBuilder query) =>
-      _pipeline.run(query, () => _client.update(query), txId: txId);
+      select(query);
 
   @override
   Future<List<Map<String, dynamic>>> delete(QueryBuilder query) =>
-      _pipeline.run(query, () => _client.delete(query), txId: txId);
+      select(query);
 
   @override
-  Future<List<Map<String, dynamic>>> rawSql(String sql, [List<dynamic>? bindings]) =>
-      _pipeline.runRaw(
-        sql, bindings ?? const [],
-        () async {
-          final result = await _client.rawQuery(sql, bindings ?? []);
-          return result is List<Map<String, dynamic>> ? result : [];
-        },
-        txId: txId,
-      );
+  Future<List<Map<String, dynamic>>> rawSql(
+    String sql, [
+    List<dynamic>? bindings,
+  ]) => _pipeline.runRaw(sql, bindings ?? const [], () async {
+    final result = await _client.rawQuery(sql, bindings ?? []);
+    return result is List<Map<String, dynamic>> ? result : [];
+  }, txId: txId);
 
   /// Stream results inside this transaction.
   @override
@@ -193,16 +196,13 @@ class KnexSQLiteTransaction extends KnexTransaction {
       }, txId: txId);
 
   @override
-  Future<T> trx<T>(Future<T> Function(KnexTransaction tx) callback) =>
-      _client.trx((client) {
-        // SQLite manages savepoints internally via its own trx() — no SAVEPOINT
-        // SQL flows through the pipeline.  Child txId still carries parent prefix
-        // so OTel spans can be correlated by txId hierarchy.
-        final childTxId =
-            '${txId}_sp_${_pipeline.nextUid()}';
-        return callback(
-          KnexSQLiteTransaction._(client, _pipeline, childTxId),
-        );
-      });
-
+  Future<T> trx<T>(
+    Future<T> Function(KnexTransaction tx) callback,
+  ) => _client.trx((client) {
+    // SQLite manages savepoints internally via its own trx() — no SAVEPOINT
+    // SQL flows through the pipeline.  Child txId still carries parent prefix
+    // so OTel spans can be correlated by txId hierarchy.
+    final childTxId = '${txId}_sp_${_pipeline.nextUid()}';
+    return callback(KnexSQLiteTransaction._(client, _pipeline, childTxId));
+  });
 }

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client.dart
@@ -198,18 +198,15 @@ class SQLiteClient extends Client {
 
   /// Executes raw SQL with positional [bindings].
   @override
-  Future<dynamic> rawQuery(String sql, List<dynamic> bindings) async {
-    return _execute(sql, bindings);
-  }
+  Future<dynamic> rawQuery(String sql, List<dynamic> bindings) =>
+      _execute(sql, bindings);
 
   @override
   Future<List<Map<String, dynamic>>> query(
     dynamic connection,
     String sql,
     List<dynamic> bindings,
-  ) async {
-    return _execute(sql, bindings);
-  }
+  ) => _execute(sql, bindings);
 
   @override
   Stream<Map<String, dynamic>> streamQuery(
@@ -260,35 +257,48 @@ class SQLiteClient extends Client {
   Future<List<Map<String, dynamic>>> _execute(
     String sql, [
     List<dynamic>? bindings,
-  ]) async {
-    if (_isClosed) throw StateError('SQLiteClient is closed');
-    final params = bindings ?? [];
-    final stmt = _stmtCache.putIfAbsent(sql, () => _db.prepare(sql));
-    final upperSql = sql.trimLeft().toUpperCase();
-    if (upperSql.startsWith('SELECT') ||
-        upperSql.startsWith('PRAGMA') ||
-        upperSql.contains('RETURNING')) {
-      final result = stmt.select(params);
-      return _mapResults(result);
-    } else {
-      stmt.execute(params);
-      return [];
+  ]) {
+    try {
+      if (_isClosed) throw StateError('SQLiteClient is closed');
+      final params = bindings ?? [];
+      final stmt = _stmtCache.putIfAbsent(sql, () => _db.prepare(sql));
+      final upperSql = sql.trimLeft().toUpperCase();
+      if (upperSql.startsWith('SELECT') ||
+          upperSql.startsWith('PRAGMA') ||
+          upperSql.contains('RETURNING')) {
+        final result = stmt.select(params);
+        return Future.value(_mapResults(result));
+      } else {
+        stmt.execute(params);
+        return Future.value([]);
+      }
+    } catch (e, st) {
+      return Future.error(e, st);
     }
   }
 
   List<Map<String, dynamic>> _mapResults(ResultSet results) {
     final rows = <Map<String, dynamic>>[];
-    for (final row in results) {
-      rows.add(Map<String, dynamic>.from(row));
+    final columns = results.columnNames;
+    for (final row in results.rows) {
+      final mapped = <String, dynamic>{};
+      for (var i = 0; i < columns.length; i++) {
+        mapped[columns[i]] = row[i];
+      }
+      rows.add(mapped);
     }
     return rows;
   }
 
   /// Execute a SELECT query via QueryBuilder.
-  Future<List<Map<String, dynamic>>> select(QueryBuilder queryBuilder) async {
+  Future<List<Map<String, dynamic>>> select(QueryBuilder queryBuilder) {
     final compiled = queryBuilder.toSQL();
-    return query(null, compiled.sql, compiled.bindings);
+    return executeCompiled(compiled);
   }
+
+  /// Execute a precompiled query without calling QueryBuilder.toSQL() again.
+  Future<List<Map<String, dynamic>>> executeCompiled(SqlString compiled) =>
+      query(null, compiled.sql, compiled.bindings);
 
   /// Execute any QueryBuilder query (SELECT, INSERT, UPDATE, DELETE).
   Future<List<Map<String, dynamic>>> execute(QueryBuilder queryBuilder) =>

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
@@ -227,6 +227,10 @@ class SQLiteClient extends Client {
     return _execute(sql, bindings);
   }
 
+  /// Executes an already compiled SQL query.
+  Future<List<Map<String, dynamic>>> executeCompiled(SqlString compiled) =>
+      _execute(compiled.sql, compiled.bindings);
+
   @override
   Future<List<Map<String, dynamic>>> query(
     dynamic connection,

--- a/drivers/knex_dart_sqlite/pubspec.yaml
+++ b/drivers/knex_dart_sqlite/pubspec.yaml
@@ -1,6 +1,6 @@
 name: knex_dart_sqlite
 description: SQLite driver for knex_dart — connect and execute queries against a SQLite database using the knex_dart query builder.
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/kartikey321/knex-dart
 homepage: https://github.com/kartikey321/knex-dart
 issue_tracker: https://github.com/kartikey321/knex-dart/issues
@@ -17,7 +17,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  knex_dart: ^1.2.0
+  knex_dart: ^1.2.1
   sqlite3: ^2.4.0
   sqlite3_web: ^0.3.0
   logging: ^1.2.0

--- a/drivers/knex_dart_sqlite/test/sqlite_error_stack_test.dart
+++ b/drivers/knex_dart_sqlite/test/sqlite_error_stack_test.dart
@@ -1,0 +1,62 @@
+import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
+import 'package:test/test.dart';
+
+const _isWeb = bool.fromEnvironment('dart.library.js_interop');
+
+void main() {
+  group('SQLiteClient error futures', () {
+    late KnexSQLite db;
+
+    setUp(() async {
+      db = await KnexSQLite.connect(filename: ':memory:');
+    });
+
+    tearDown(() => db.close());
+
+    test(
+      'invalid SQL preserves the originating stack trace',
+      () async {
+        Object? error;
+        StackTrace? stackTrace;
+
+        try {
+          await db.rawSql('SELEC invalid syntax');
+        } catch (e, st) {
+          error = e;
+          stackTrace = st;
+        }
+
+        expect(error, isNotNull);
+        expect(stackTrace, isNotNull);
+        expect(stackTrace.toString(), contains('_execute'));
+      },
+      skip: _isWeb ? 'native stack symbol assertion' : false,
+    );
+
+    test(
+      'constraint failures preserve the originating stack trace',
+      () async {
+        await db.rawSql(
+          'CREATE TABLE unique_items (id INTEGER PRIMARY KEY, name TEXT UNIQUE)',
+        );
+        await db.rawSql('INSERT INTO unique_items (name) VALUES (?)', ['same']);
+
+        Object? error;
+        StackTrace? stackTrace;
+        try {
+          await db.rawSql('INSERT INTO unique_items (name) VALUES (?)', [
+            'same',
+          ]);
+        } catch (e, st) {
+          error = e;
+          stackTrace = st;
+        }
+
+        expect(error, isNotNull);
+        expect(stackTrace, isNotNull);
+        expect(stackTrace.toString(), contains('_execute'));
+      },
+      skip: _isWeb ? 'native stack symbol assertion' : false,
+    );
+  });
+}

--- a/drivers/knex_dart_sqlite/test/sqlite_error_stack_test.dart
+++ b/drivers/knex_dart_sqlite/test/sqlite_error_stack_test.dart
@@ -58,5 +58,26 @@ void main() {
       },
       skip: _isWeb ? 'native stack symbol assertion' : false,
     );
+
+    test(
+      'compiled query failures preserve the originating stack trace',
+      () async {
+        final query = db.queryBuilder().table('missing_items').select(['id']);
+
+        Object? error;
+        StackTrace? stackTrace;
+        try {
+          await db.select(query);
+        } catch (e, st) {
+          error = e;
+          stackTrace = st;
+        }
+
+        expect(error, isNotNull);
+        expect(stackTrace, isNotNull);
+        expect(stackTrace.toString(), contains('_execute'));
+      },
+      skip: _isWeb ? 'native stack symbol assertion' : false,
+    );
   });
 }

--- a/examples/knex_otel_sqlite_app/README.md
+++ b/examples/knex_otel_sqlite_app/README.md
@@ -1,0 +1,41 @@
+# knex_dart OTel SQLite Example
+
+Runs a real `KnexSQLite` workload through `KnexOtelInterceptor` and exports
+spans plus `db.client.operation.duration` metrics through the Dartastic
+OpenTelemetry SDK.
+
+The default mode uses console exporters, so it works without Docker:
+
+```bash
+dart pub get
+dart run bin/sqlite_otel_collector.dart
+```
+
+To send telemetry to an OpenTelemetry Collector over OTLP/HTTP:
+
+```bash
+dart run bin/sqlite_otel_collector.dart \
+  --otlp-http \
+  --endpoint=http://localhost:4318 \
+  --insecure
+```
+
+To send telemetry over OTLP/gRPC:
+
+```bash
+dart run bin/sqlite_otel_collector.dart \
+  --otlp-grpc \
+  --endpoint=localhost:4317 \
+  --insecure
+```
+
+The workload emits spans for:
+
+- `CREATE` schema statements
+- `INSERT`
+- `SELECT`
+- transaction `UPDATE` and `SELECT`
+- one intentional failing raw SQL query, to verify error span export
+
+This package is intentionally standalone. It uses the current SDK with a
+dependency override while `knex_dart_otel` itself remains API-only.

--- a/examples/knex_otel_sqlite_app/bin/sqlite_otel_collector.dart
+++ b/examples/knex_otel_sqlite_app/bin/sqlite_otel_collector.dart
@@ -1,0 +1,172 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dartastic_opentelemetry/dartastic_opentelemetry.dart';
+import 'package:knex_dart_otel/knex_dart_otel.dart';
+import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
+
+Future<void> main(List<String> args) async {
+  final config = _ExampleConfig.parse(args);
+  await _initializeOtel(config);
+
+  final db = await KnexSQLite.connect(
+    filename: ':memory:',
+    interceptors: [
+      KnexOtelInterceptor(
+        tracer: OTel.tracer(),
+        options: KnexOtelOptions(
+          responseHook: (span, ctx, result) {
+            if (result.rowCount != null) {
+              span.setIntAttribute('db.response.row_count', result.rowCount!);
+            }
+          },
+        ),
+      ),
+    ],
+  );
+
+  try {
+    await _runWorkload(db);
+    print('knex_dart OTel SQLite example completed.');
+  } finally {
+    await db.close();
+    await Future<void>.delayed(const Duration(seconds: 2));
+    await OTel.shutdown();
+  }
+}
+
+Future<void> _initializeOtel(_ExampleConfig config) async {
+  final spanExporter = switch (config.exporter) {
+    _ExporterKind.console => ConsoleExporter(),
+    _ExporterKind.otlpHttp => OtlpHttpSpanExporter(
+      OtlpHttpExporterConfig(endpoint: config.endpoint),
+    ),
+    _ExporterKind.otlpGrpc => OtlpGrpcSpanExporter(
+      OtlpGrpcExporterConfig(
+        endpoint: _grpcEndpoint(config.endpoint),
+        insecure: config.insecure,
+      ),
+    ),
+  };
+
+  final metricExporter = switch (config.exporter) {
+    _ExporterKind.console => ConsoleMetricExporter(),
+    _ExporterKind.otlpHttp => OtlpHttpMetricExporter(
+      OtlpHttpMetricExporterConfig(endpoint: config.endpoint),
+    ),
+    _ExporterKind.otlpGrpc => OtlpGrpcMetricExporter(
+      OtlpGrpcMetricExporterConfig(
+        endpoint: _grpcEndpoint(config.endpoint),
+        insecure: config.insecure,
+      ),
+    ),
+  };
+
+  await OTel.initialize(
+    endpoint: config.endpoint,
+    secure: !config.insecure,
+    serviceName: 'knex-otel-sqlite-example',
+    serviceVersion: '0.0.1',
+    tracerName: 'knex-otel-sqlite-example',
+    tracerVersion: '0.0.1',
+    enableLogs: false,
+    spanProcessor: SimpleSpanProcessor(spanExporter),
+    metricReader: PeriodicExportingMetricReader(
+      metricExporter,
+      interval: const Duration(seconds: 1),
+    ),
+  );
+}
+
+Future<void> _runWorkload(KnexSQLite db) async {
+  await db.executeSchema((schema) {
+    schema.createTable('users', (table) {
+      table.increments('id');
+      table.string('name').notNullable();
+      table.integer('age');
+      table.boolean('active').defaultTo(true);
+    });
+  });
+
+  await db.insert(
+    db('users').insert([
+      {'name': 'Alice', 'age': 30, 'active': true},
+      {'name': 'Bob', 'age': 41, 'active': false},
+      {'name': 'Cara', 'age': 28, 'active': true},
+    ]),
+  );
+
+  await db.select(
+    db('users')
+        .select(['id', 'name', 'age'])
+        .where('active', '=', true)
+        .orderBy('age', 'desc'),
+  );
+
+  await db.trx((tx) async {
+    await tx.update(
+      tx('users').where('name', '=', 'Alice').update({'age': 31}),
+    );
+    await tx.select(tx('users').select(['id', 'name', 'age']));
+  });
+
+  try {
+    await db.rawSql('SELECT * FROM missing_table');
+  } catch (_) {
+    // Intentional: verifies error span status and exception event export.
+  }
+}
+
+String _grpcEndpoint(String endpoint) {
+  final uri = Uri.tryParse(endpoint);
+  if (uri == null || uri.host.isEmpty) return endpoint;
+  return '${uri.host}:${uri.hasPort ? uri.port : 4317}';
+}
+
+class _ExampleConfig {
+  final _ExporterKind exporter;
+  final String endpoint;
+  final bool insecure;
+
+  const _ExampleConfig({
+    required this.exporter,
+    required this.endpoint,
+    required this.insecure,
+  });
+
+  factory _ExampleConfig.parse(List<String> args) {
+    var exporter = _ExporterKind.console;
+    var endpoint =
+        Platform.environment['OTEL_EXPORTER_OTLP_ENDPOINT'] ??
+        'http://localhost:4318';
+    var insecure =
+        Platform.environment['OTEL_EXPORTER_OTLP_INSECURE'] == 'true';
+
+    for (final arg in args) {
+      if (arg == '--console') {
+        exporter = _ExporterKind.console;
+      } else if (arg == '--otlp-http') {
+        exporter = _ExporterKind.otlpHttp;
+      } else if (arg == '--otlp-grpc') {
+        exporter = _ExporterKind.otlpGrpc;
+        endpoint =
+            Platform.environment['OTEL_EXPORTER_OTLP_ENDPOINT'] ??
+            'localhost:4317';
+      } else if (arg.startsWith('--endpoint=')) {
+        endpoint = arg.substring('--endpoint='.length);
+      } else if (arg == '--insecure') {
+        insecure = true;
+      } else {
+        throw ArgumentError('Unknown argument: $arg');
+      }
+    }
+
+    return _ExampleConfig(
+      exporter: exporter,
+      endpoint: endpoint,
+      insecure: insecure,
+    );
+  }
+}
+
+enum _ExporterKind { console, otlpHttp, otlpGrpc }

--- a/examples/knex_otel_sqlite_app/pubspec.yaml
+++ b/examples/knex_otel_sqlite_app/pubspec.yaml
@@ -1,0 +1,27 @@
+name: knex_otel_sqlite_app
+description: Example app exporting knex_dart SQLite telemetry through OpenTelemetry.
+publish_to: none
+version: 0.0.1
+
+environment:
+  sdk: ^3.10.0
+
+dependencies:
+  dartastic_opentelemetry: ^0.9.5
+  knex_dart: ^1.2.0
+  knex_dart_otel: ^0.1.0
+  knex_dart_sqlite: ^0.2.0
+
+dev_dependencies:
+  lints: ^6.0.0
+
+dependency_overrides:
+  dartastic_opentelemetry_api: 1.0.0-beta.2
+  knex_dart:
+    path: ../../packages/knex_dart
+  knex_dart_capabilities:
+    path: ../../packages/knex_dart_capabilities
+  knex_dart_otel:
+    path: ../../integrations/knex_dart_otel
+  knex_dart_sqlite:
+    path: ../../drivers/knex_dart_sqlite

--- a/integrations/knex_dart_otel/CHANGELOG.md
+++ b/integrations/knex_dart_otel/CHANGELOG.md
@@ -7,4 +7,7 @@
 - Records OpenTelemetry client spans for query, raw SQL, schema, transaction, stream, and D1 batch operations routed through the interceptor pipeline.
 - Records `db.client.operation.duration` histogram metrics.
 - Added request/response hooks via `KnexOtelOptions`.
-
+- Added DB semantic convention span attributes, span status, error type, and
+  exception event coverage.
+- Uses direct OpenTelemetry context activation so the interceptor is the single
+  source of DB exception events when running with a real SDK.

--- a/integrations/knex_dart_otel/LICENSE
+++ b/integrations/knex_dart_otel/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Kartikey
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/integrations/knex_dart_otel/README.md
+++ b/integrations/knex_dart_otel/README.md
@@ -100,3 +100,17 @@ Construct `KnexOtelInterceptor` after your OpenTelemetry SDK is installed. The d
 
 Pass `operationDurationHistogram` explicitly if you need full control over meter/provider binding.
 
+## Real SDK example
+
+This package intentionally depends only on the OpenTelemetry API. A standalone
+example app in the repository shows end-to-end export through the Dartastic
+OpenTelemetry SDK:
+
+```bash
+cd examples/knex_otel_sqlite_app
+dart pub get
+dart run bin/sqlite_otel_collector.dart
+```
+
+The example uses console exporters by default and also supports OTLP HTTP/gRPC
+collector endpoints.

--- a/integrations/knex_dart_otel/lib/src/knex_otel.dart
+++ b/integrations/knex_dart_otel/lib/src/knex_otel.dart
@@ -255,10 +255,11 @@ class KnexOtelInterceptor extends QueryInterceptor {
     final sw = Stopwatch()..start();
     try {
       // Make the DB span current so any child spans (HTTP, TCP) created inside
-      // the driver are automatically parented to it.
-      final result = await _tracer.withSpanAsync(span, next);
+      // the driver are automatically parented to it. Use Context directly
+      // instead of tracer.withSpanAsync() because some SDKs also record thrown
+      // exceptions there; the interceptor owns DB exception recording below.
+      final result = await Context.current.withSpan(span).run(next);
       sw.stop();
-
 
       span.setStatus(SpanStatusCode.Ok);
 
@@ -411,17 +412,20 @@ class KnexOtelInterceptor extends QueryInterceptor {
         try {
           // Make the DB span current during listen() so any child spans created
           // by stream setup or stream callbacks are parented to it.
-          upstream = _tracer.withSpan(span, () => next().listen(
-            controller.add,
-            onError: (Object e, StackTrace st) {
-              finishOnce(isError: true, error: e, stackTrace: st);
-              controller.addError(e, st);
-            },
-            onDone: () {
-              finishOnce();
-              controller.close();
-            },
-          ));
+          upstream = _tracer.withSpan(
+            span,
+            () => next().listen(
+              controller.add,
+              onError: (Object e, StackTrace st) {
+                finishOnce(isError: true, error: e, stackTrace: st);
+                controller.addError(e, st);
+              },
+              onDone: () {
+                finishOnce();
+                controller.close();
+              },
+            ),
+          );
         } catch (e, st) {
           // next() threw synchronously — end span immediately and forward.
           finishOnce(isError: true, error: e, stackTrace: st);

--- a/integrations/knex_dart_otel/test/otel_span_attributes_test.dart
+++ b/integrations/knex_dart_otel/test/otel_span_attributes_test.dart
@@ -404,5 +404,37 @@ void main() {
       expect(capturedSpan.attributes.getString('db.system.name'), 'sqlite');
       expect(capturedSpan.attributes.getString('db.operation.name'), 'SELECT');
     });
+
+    test('ends span when subscription is cancelled mid-stream', () async {
+      late APISpan capturedSpan;
+      var responseHookCalls = 0;
+      final otel = KnexOtelInterceptor(
+        tracer: tracer,
+        operationDurationHistogram: histogram,
+        options: KnexOtelOptions(
+          requestHook: (span, _) => capturedSpan = span,
+          responseHook: (_, _, result) {
+            responseHookCalls++;
+            expect(result.isError, isFalse);
+          },
+        ),
+      );
+
+      final subscription = otel
+          .interceptStream<int>(
+            _ctx(dbSystem: 'sqlite', operationName: 'SELECT'),
+            () => Stream.periodic(
+              const Duration(milliseconds: 1),
+              (index) => index,
+            ),
+          )
+          .listen((_) {});
+
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+      await subscription.cancel();
+
+      expect(capturedSpan.isEnded, isTrue);
+      expect(responseHookCalls, 1);
+    });
   });
 }

--- a/integrations/knex_dart_otel/test/otel_span_attributes_test.dart
+++ b/integrations/knex_dart_otel/test/otel_span_attributes_test.dart
@@ -1,0 +1,408 @@
+/// Direct OTel span attribute verification tests.
+library;
+
+import 'package:dartastic_opentelemetry_api/dartastic_opentelemetry_api.dart';
+import 'package:knex_dart/knex_dart.dart';
+import 'package:knex_dart_otel/knex_dart_otel.dart';
+import 'package:test/test.dart';
+
+class CapturingHistogram extends APIHistogram<double> {
+  final List<(double value, Map<String, Object> attrs)> recordings = [];
+
+  CapturingHistogram(APIMeter meter)
+    : super('db.client.operation.duration', null, 's', true, meter);
+
+  @override
+  void record(double value, [Attributes? attributes]) {
+    recordings.add((value, {}));
+  }
+
+  @override
+  void recordWithMap(double value, Map<String, Object> attributeMap) {
+    recordings.add((value, Map<String, Object>.from(attributeMap)));
+  }
+}
+
+QueryExecutionContext _ctx({
+  String dbSystem = 'postgresql',
+  String? database = 'mydb',
+  String? serverAddress = 'localhost',
+  int? serverPort = 5432,
+  String sql = 'select * from "users"',
+  String operationName = 'SELECT',
+  String? collectionName = 'users',
+  String querySummary = 'SELECT users',
+  String? txId,
+}) => QueryExecutionContext(
+  dbSystem: dbSystem,
+  database: database,
+  serverAddress: serverAddress,
+  serverPort: serverPort,
+  sql: sql,
+  parameters: const [],
+  operationName: operationName,
+  collectionName: collectionName,
+  querySummary: querySummary,
+  txId: txId,
+);
+
+void main() {
+  late APITracer tracer;
+  late CapturingHistogram histogram;
+
+  setUp(() {
+    OTelAPI.reset();
+    OTelAPI.initialize(
+      endpoint: 'http://localhost:4317',
+      serviceName: 'knex-otel-span-attributes-test',
+      serviceVersion: '0.0.1',
+    );
+    tracer = OTelAPI.tracer('knex_dart_otel_span_attributes_test');
+    histogram = CapturingHistogram(
+      OTelAPI.meterProvider().getMeter(
+        name: 'knex_dart_otel_span_attributes_test',
+      ),
+    );
+  });
+
+  tearDown(() => OTelAPI.reset());
+
+  KnexOtelInterceptor interceptorCapturing(void Function(APISpan span) hook) {
+    return KnexOtelInterceptor(
+      tracer: tracer,
+      operationDurationHistogram: histogram,
+      options: KnexOtelOptions(requestHook: (span, _) => hook(span)),
+    );
+  }
+
+  group('span attributes', () {
+    test('db.system.name equals ctx.dbSystem', () async {
+      for (final dbSystem in ['postgresql', 'sqlite', 'mysql']) {
+        late APISpan capturedSpan;
+        final otel = interceptorCapturing((span) => capturedSpan = span);
+
+        await otel.intercept<List<Map<String, dynamic>>>(
+          _ctx(dbSystem: dbSystem),
+          () async => [],
+        );
+
+        expect(capturedSpan.attributes.getString('db.system.name'), dbSystem);
+      }
+    });
+
+    test('db.operation.name equals ctx.operationName', () async {
+      for (final operationName in ['SELECT', 'INSERT']) {
+        late APISpan capturedSpan;
+        final otel = interceptorCapturing((span) => capturedSpan = span);
+
+        await otel.intercept<List<Map<String, dynamic>>>(
+          _ctx(operationName: operationName),
+          () async => [],
+        );
+
+        expect(
+          capturedSpan.attributes.getString('db.operation.name'),
+          operationName,
+        );
+      }
+    });
+
+    test('db.namespace set only when database is provided', () async {
+      late APISpan withDatabase;
+      await interceptorCapturing(
+        (span) => withDatabase = span,
+      ).intercept<List<Map<String, dynamic>>>(
+        _ctx(database: 'orders_db'),
+        () async => [],
+      );
+
+      late APISpan withoutDatabase;
+      await interceptorCapturing(
+        (span) => withoutDatabase = span,
+      ).intercept<List<Map<String, dynamic>>>(
+        _ctx(database: null),
+        () async => [],
+      );
+
+      expect(withDatabase.attributes.getString('db.namespace'), 'orders_db');
+      expect(
+        withoutDatabase.attributes.toMap(),
+        isNot(contains('db.namespace')),
+      );
+    });
+
+    test(
+      'db.collection.name set only when collectionName is provided',
+      () async {
+        late APISpan withCollection;
+        await interceptorCapturing(
+          (span) => withCollection = span,
+        ).intercept<List<Map<String, dynamic>>>(
+          _ctx(collectionName: 'users'),
+          () async => [],
+        );
+
+        late APISpan withoutCollection;
+        await interceptorCapturing(
+          (span) => withoutCollection = span,
+        ).intercept<List<Map<String, dynamic>>>(
+          _ctx(collectionName: null),
+          () async => [],
+        );
+
+        expect(
+          withCollection.attributes.getString('db.collection.name'),
+          'users',
+        );
+        expect(
+          withoutCollection.attributes.toMap(),
+          isNot(contains('db.collection.name')),
+        );
+      },
+    );
+
+    test(
+      'db.query.text equals ctx.sql when captureQueryText is true',
+      () async {
+        late APISpan capturedSpan;
+        final sql = 'select * from "users" where "id" = ?';
+
+        await interceptorCapturing(
+          (span) => capturedSpan = span,
+        ).intercept<List<Map<String, dynamic>>>(_ctx(sql: sql), () async => []);
+
+        expect(capturedSpan.attributes.getString('db.query.text'), sql);
+      },
+    );
+
+    test('db.query.text absent when captureQueryText is false', () async {
+      late APISpan capturedSpan;
+      final otel = KnexOtelInterceptor(
+        tracer: tracer,
+        operationDurationHistogram: histogram,
+        options: KnexOtelOptions(
+          captureQueryText: false,
+          requestHook: (span, _) => capturedSpan = span,
+        ),
+      );
+
+      await otel.intercept<List<Map<String, dynamic>>>(_ctx(), () async => []);
+
+      expect(capturedSpan.attributes.toMap(), isNot(contains('db.query.text')));
+    });
+
+    test(
+      'db.query.text truncated to maxQueryTextLength plus ellipsis',
+      () async {
+        late APISpan capturedSpan;
+        const maxQueryTextLength = 12;
+        final sql = 'select * from users where email = ? and active = ?';
+        final otel = KnexOtelInterceptor(
+          tracer: tracer,
+          operationDurationHistogram: histogram,
+          options: KnexOtelOptions(
+            maxQueryTextLength: maxQueryTextLength,
+            requestHook: (span, _) => capturedSpan = span,
+          ),
+        );
+
+        await otel.intercept<List<Map<String, dynamic>>>(
+          _ctx(sql: sql),
+          () async => [],
+        );
+
+        final text = capturedSpan.attributes.getString('db.query.text')!;
+        expect(text.length, maxQueryTextLength + 1);
+        expect(text, endsWith('…'));
+      },
+    );
+
+    test('server.address set only when serverAddress is non-null', () async {
+      late APISpan withAddress;
+      await interceptorCapturing(
+        (span) => withAddress = span,
+      ).intercept<List<Map<String, dynamic>>>(
+        _ctx(serverAddress: 'db.local'),
+        () async => [],
+      );
+
+      late APISpan withoutAddress;
+      await interceptorCapturing(
+        (span) => withoutAddress = span,
+      ).intercept<List<Map<String, dynamic>>>(
+        _ctx(serverAddress: null),
+        () async => [],
+      );
+
+      expect(withAddress.attributes.getString('server.address'), 'db.local');
+      expect(
+        withoutAddress.attributes.toMap(),
+        isNot(contains('server.address')),
+      );
+    });
+
+    test('server.port set only when serverPort is non-null', () async {
+      late APISpan withPort;
+      await interceptorCapturing(
+        (span) => withPort = span,
+      ).intercept<List<Map<String, dynamic>>>(
+        _ctx(serverPort: 5433),
+        () async => [],
+      );
+
+      late APISpan withoutPort;
+      await interceptorCapturing(
+        (span) => withoutPort = span,
+      ).intercept<List<Map<String, dynamic>>>(
+        _ctx(serverPort: null),
+        () async => [],
+      );
+
+      expect(withPort.attributes.getInt('server.port'), 5433);
+      expect(withoutPort.attributes.toMap(), isNot(contains('server.port')));
+    });
+  });
+
+  group('span lifecycle and status', () {
+    test('span name equals ctx.querySummary', () async {
+      late APISpan capturedSpan;
+
+      await interceptorCapturing(
+        (span) => capturedSpan = span,
+      ).intercept<List<Map<String, dynamic>>>(
+        _ctx(querySummary: 'SELECT active users'),
+        () async => [],
+      );
+
+      expect(capturedSpan.name, 'SELECT active users');
+    });
+
+    test('span status is Ok on successful query', () async {
+      late APISpan capturedSpan;
+
+      await interceptorCapturing(
+        (span) => capturedSpan = span,
+      ).intercept<List<Map<String, dynamic>>>(_ctx(), () async => []);
+
+      expect(capturedSpan.status, SpanStatusCode.Ok);
+    });
+
+    test('span status is Error when query throws', () async {
+      late APISpan capturedSpan;
+
+      await expectLater(
+        () => interceptorCapturing(
+          (span) => capturedSpan = span,
+        ).intercept<void>(_ctx(), () async => throw StateError('fail')),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(capturedSpan.status, SpanStatusCode.Error);
+    });
+
+    test('error.type attribute is exception runtimeType string', () async {
+      for (final error in [StateError('fail'), ArgumentError('bad input')]) {
+        late APISpan capturedSpan;
+
+        await expectLater(
+          () => interceptorCapturing(
+            (span) => capturedSpan = span,
+          ).intercept<void>(_ctx(), () async => throw error),
+          throwsA(isA<Object>()),
+        );
+
+        expect(
+          capturedSpan.attributes.getString('error.type'),
+          error.runtimeType.toString(),
+        );
+      }
+    });
+
+    test('spanEvents contains exception event on error', () async {
+      late APISpan capturedSpan;
+
+      await expectLater(
+        () => interceptorCapturing(
+          (span) => capturedSpan = span,
+        ).intercept<void>(_ctx(), () async => throw StateError('fail')),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(
+        capturedSpan.spanEvents?.any((event) => event.name == 'exception'),
+        isTrue,
+      );
+    });
+
+    test('isEnded is true after intercept returns', () async {
+      late APISpan capturedSpan;
+
+      await interceptorCapturing(
+        (span) => capturedSpan = span,
+      ).intercept<List<Map<String, dynamic>>>(_ctx(), () async => []);
+
+      expect(capturedSpan.isEnded, isTrue);
+    });
+  });
+
+  group('responseHook', () {
+    test('receives successful KnexOtelResult with rowCount', () async {
+      KnexOtelResult? capturedResult;
+      final otel = KnexOtelInterceptor(
+        tracer: tracer,
+        operationDurationHistogram: histogram,
+        options: KnexOtelOptions(
+          responseHook: (_, _, result) => capturedResult = result,
+        ),
+      );
+
+      await otel.intercept<List<int>>(_ctx(), () async => [1, 2, 3]);
+
+      expect(capturedResult, isNotNull);
+      expect(capturedResult!.isError, isFalse);
+      expect(capturedResult!.rowCount, 3);
+    });
+
+    test('receives error KnexOtelResult with error object', () async {
+      KnexOtelResult? capturedResult;
+      final error = StateError('fail');
+      final otel = KnexOtelInterceptor(
+        tracer: tracer,
+        operationDurationHistogram: histogram,
+        options: KnexOtelOptions(
+          responseHook: (_, _, result) => capturedResult = result,
+        ),
+      );
+
+      await expectLater(
+        () => otel.intercept<void>(_ctx(), () async => throw error),
+        throwsA(same(error)),
+      );
+
+      expect(capturedResult, isNotNull);
+      expect(capturedResult!.isError, isTrue);
+      expect(capturedResult!.error, same(error));
+    });
+  });
+
+  group('interceptStream', () {
+    test('sets db.system.name and db.operation.name', () async {
+      late APISpan capturedSpan;
+      final otel = KnexOtelInterceptor(
+        tracer: tracer,
+        operationDurationHistogram: histogram,
+        options: KnexOtelOptions(requestHook: (span, _) => capturedSpan = span),
+      );
+
+      await otel
+          .interceptStream<int>(
+            _ctx(dbSystem: 'sqlite', operationName: 'SELECT'),
+            () => Stream.fromIterable([1, 2, 3]),
+          )
+          .toList();
+
+      expect(capturedSpan.attributes.getString('db.system.name'), 'sqlite');
+      expect(capturedSpan.attributes.getString('db.operation.name'), 'SELECT');
+    });
+  });
+}

--- a/packages/knex_dart/CHANGELOG.md
+++ b/packages/knex_dart/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.2.1
+
+- Improved query compilation hot paths by replacing timestamp/random UID
+  generation with per-isolate counters.
+- Avoided enum string splitting when resolving compiled query methods.
+- Documented the public `QueryInterceptor` / `QueryExecutionContext` pipeline
+  used by live driver wrappers for tracing, metrics, logging, and policy hooks.
+- Added a compiled-query interceptor path so driver wrappers can avoid
+  compiling the same query twice when interceptors are installed.
+- No SQL escaping, binding, identifier wrapping, or generated SQL semantics
+  changed in this release.
+
 ## 1.2.0
 
 - Added `KnexQuery` for dialect-only SQL generation via `KnexQuery.forDialect(...)` and `KnexQuery.forClient(...)`.

--- a/packages/knex_dart/README.md
+++ b/packages/knex_dart/README.md
@@ -50,7 +50,7 @@ Add the driver for your database — it pulls in `knex_dart` automatically:
 dependencies:
   knex_dart_postgres: ^0.2.0   # PostgreSQL
   # knex_dart_mysql: ^0.2.0    # MySQL
-  # knex_dart_sqlite: ^0.2.0   # SQLite
+  # knex_dart_sqlite: ^0.2.1   # SQLite
   # knex_dart_duckdb: ^0.1.0   # DuckDB (OLAP / browser WASM)
 ```
 
@@ -58,7 +58,7 @@ For SQL generation only (no live connection):
 
 ```yaml
 dependencies:
-  knex_dart: ^1.2.0
+  knex_dart: ^1.2.1
   knex_dart_capabilities: ^0.2.0
 ```
 
@@ -142,6 +142,43 @@ print(q2.from('users').where('active', '=', true).toSQL().sql);
 ```
 
 Supported dialects: `pg`, `mysql2`, `sqlite3`, `duckdb`, `snowflake`, `bigquery`, `turso`, `d1`, `mariadb`, `redshift`.
+
+## Query Interceptors
+
+Live driver wrappers can route query execution through `QueryInterceptor`s for
+tracing, metrics, logging, or custom policy checks. Interceptors receive a
+`QueryExecutionContext` with stable metadata such as `dbSystem`, `sql`,
+`parameters`, `operationName`, `collectionName`, `querySummary`, and `txId`.
+
+```dart
+import 'package:knex_dart/knex_dart.dart';
+import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
+
+class AuditInterceptor extends QueryInterceptor {
+  @override
+  Future<T> intercept<T>(
+    QueryExecutionContext ctx,
+    Future<T> Function() next,
+  ) async {
+    final started = DateTime.now();
+    try {
+      return await next();
+    } finally {
+      final elapsed = DateTime.now().difference(started);
+      // Send ctx.operationName, ctx.querySummary, and elapsed to your logger.
+    }
+  }
+}
+
+final db = await KnexSQLite.connect(
+  filename: ':memory:',
+  interceptors: [AuditInterceptor()],
+);
+```
+
+Use [`knex_dart_otel`](https://pub.dev/packages/knex_dart_otel) when you want
+OpenTelemetry spans and DB client duration metrics without writing your own
+interceptor.
 
 ## Query Builder
 

--- a/packages/knex_dart/lib/src/client/query_interceptor.dart
+++ b/packages/knex_dart/lib/src/client/query_interceptor.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import '../query/query_builder.dart';
+import '../query/sql_string.dart';
 import '../util/enums.dart';
 
 /// Metadata about a single query execution, passed through the interceptor
@@ -59,17 +60,17 @@ class QueryExecutionContext {
 
   /// Returns a copy with [txId] set.
   QueryExecutionContext withTxId(String txId) => QueryExecutionContext(
-        dbSystem: dbSystem,
-        sql: sql,
-        parameters: parameters,
-        operationName: operationName,
-        querySummary: querySummary,
-        database: database,
-        serverAddress: serverAddress,
-        serverPort: serverPort,
-        collectionName: collectionName,
-        txId: txId,
-      );
+    dbSystem: dbSystem,
+    sql: sql,
+    parameters: parameters,
+    operationName: operationName,
+    querySummary: querySummary,
+    database: database,
+    serverAddress: serverAddress,
+    serverPort: serverPort,
+    collectionName: collectionName,
+    txId: txId,
+  );
 }
 
 /// Intercepts query execution.
@@ -93,10 +94,7 @@ class QueryExecutionContext {
 /// ```
 abstract class QueryInterceptor {
   /// Intercepts a future-based query execution.
-  Future<T> intercept<T>(
-    QueryExecutionContext ctx,
-    Future<T> Function() next,
-  );
+  Future<T> intercept<T>(QueryExecutionContext ctx, Future<T> Function() next);
 
   /// Intercepts a streaming query execution.
   ///
@@ -109,8 +107,7 @@ abstract class QueryInterceptor {
   Stream<T> interceptStream<T>(
     QueryExecutionContext ctx,
     Stream<T> Function() next,
-  ) =>
-      next();
+  ) => next();
 }
 
 /// Holds connection-level metadata and the ordered list of [QueryInterceptor]s
@@ -175,6 +172,19 @@ class KnexInterceptorPipeline {
   }) {
     if (!_active) return execute();
     final compiled = query.toSQL();
+    return runCompiled(query, compiled, (_) => execute(), txId: txId);
+  }
+
+  /// Runs [execute] through the interceptor pipeline using an already compiled
+  /// query. Driver wrappers can use this to avoid calling `toSQL()` twice when
+  /// interceptors need SQL metadata before execution.
+  Future<T> runCompiled<T>(
+    QueryBuilder query,
+    SqlString compiled,
+    Future<T> Function(SqlString compiled) execute, {
+    String? txId,
+  }) {
+    if (!_active) return execute(compiled);
     final op = queryMethodToSqlOperation(query.method);
     final table = query.tableName;
     final ctx = QueryExecutionContext(
@@ -189,7 +199,7 @@ class KnexInterceptorPipeline {
       querySummary: table != null ? '$op $table' : op,
       txId: txId,
     );
-    return _chain(ctx, 0, execute);
+    return _chain(ctx, 0, () => execute(compiled));
   }
 
   // ── Raw SQL ────────────────────────────────────────────────────────────────

--- a/packages/knex_dart/lib/src/query/query_compiler.dart
+++ b/packages/knex_dart/lib/src/query/query_compiler.dart
@@ -16,6 +16,8 @@ import 'sql_string.dart';
 /// - Manage bindings for parameterized queries
 /// - Generate unique query IDs
 class QueryCompiler {
+  static int _uidCounter = 0;
+
   final Client client;
   final QueryBuilder builder;
 
@@ -36,7 +38,7 @@ class QueryCompiler {
 
   QueryCompiler(this.client, this.builder) {
     // Get method from builder
-    method = builder.method.toString().split('.').last;
+    method = builder.method.name;
 
     // Get single values (table, etc.)
     single = Map<String, dynamic>.from(builder.single);
@@ -1329,8 +1331,7 @@ class QueryCompiler {
       // If caller passes only an order expression (e.g. `"score" desc`),
       // normalize it to `order by ...` inside OVER(...).
       var overClause = rawSQL.sql.trim();
-      if (overClause.isNotEmpty &&
-          !_isCompleteAnalyticOverClause(overClause)) {
+      if (overClause.isNotEmpty && !_isCompleteAnalyticOverClause(overClause)) {
         overClause = 'order by $overClause';
       }
       sql += overClause;
@@ -1450,16 +1451,10 @@ class QueryCompiler {
     return '$prefix ${ctes.join(', ')}';
   }
 
-  /// Generate unique query ID
-  ///
-  /// Same pattern as Raw._generateUid()
+  /// Generate unique query ID.
   String _generateUid() {
-    final timestamp = DateTime.now().microsecondsSinceEpoch.toRadixString(36);
-    final random =
-        (DateTime.now().microsecond * 1000 + DateTime.now().millisecond)
-            .toRadixString(36);
-    final uid = '$timestamp$random';
-    return uid.substring(0, uid.length < 12 ? uid.length : 12);
+    _uidCounter = (_uidCounter + 1) & 0x7FFFFFFFFFFFFFFF;
+    return 'q${_uidCounter.toRadixString(16).padLeft(11, '0')}';
   }
 
   /// Compile INSERT query

--- a/packages/knex_dart/lib/src/query/query_compiler.dart
+++ b/packages/knex_dart/lib/src/query/query_compiler.dart
@@ -1453,8 +1453,9 @@ class QueryCompiler {
 
   /// Generate unique query ID.
   String _generateUid() {
-    _uidCounter = (_uidCounter + 1) & 0x7FFFFFFF;
-    return 'q${_uidCounter.toRadixString(16).padLeft(8, '0')}';
+    const maxJsSafeInt = 0x1FFFFFFFFFFFFF;
+    _uidCounter = (_uidCounter + 1) & maxJsSafeInt;
+    return 'q${_uidCounter.toRadixString(16).padLeft(14, '0')}';
   }
 
   /// Compile INSERT query

--- a/packages/knex_dart/lib/src/query/query_compiler.dart
+++ b/packages/knex_dart/lib/src/query/query_compiler.dart
@@ -1453,8 +1453,8 @@ class QueryCompiler {
 
   /// Generate unique query ID.
   String _generateUid() {
-    _uidCounter = (_uidCounter + 1) & 0x7FFFFFFFFFFFFFFF;
-    return 'q${_uidCounter.toRadixString(16).padLeft(11, '0')}';
+    _uidCounter = (_uidCounter + 1) & 0x7FFFFFFF;
+    return 'q${_uidCounter.toRadixString(16).padLeft(8, '0')}';
   }
 
   /// Compile INSERT query

--- a/packages/knex_dart/lib/src/raw.dart
+++ b/packages/knex_dart/lib/src/raw.dart
@@ -141,8 +141,9 @@ class Raw {
 
   /// Generate a unique ID for this query.
   String _generateUid() {
-    _uidCounter = (_uidCounter + 1) & 0x7FFFFFFF;
-    return 'r${_uidCounter.toRadixString(16).padLeft(8, '0')}';
+    const maxJsSafeInt = 0x1FFFFFFFFFFFFF;
+    _uidCounter = (_uidCounter + 1) & maxJsSafeInt;
+    return 'r${_uidCounter.toRadixString(16).padLeft(14, '0')}';
   }
 
   /// Validate bindings don't contain null values

--- a/packages/knex_dart/lib/src/raw.dart
+++ b/packages/knex_dart/lib/src/raw.dart
@@ -23,6 +23,8 @@ import 'formatter/raw_formatter.dart';
 /// });
 /// ```
 class Raw {
+  static int _uidCounter = 0;
+
   final Client _client;
   String _sql = '';
   dynamic _bindings =
@@ -137,20 +139,10 @@ class Raw {
     return SqlString(compiledSql, compiledBindings, method: 'raw', uid: uid);
   }
 
-  /// Generate a unique ID for this query
-  ///
-  /// JS uses nanoid() which generates 21-char alphanumeric IDs
-  /// We'll use a simpler approach: timestamp + random
+  /// Generate a unique ID for this query.
   String _generateUid() {
-    final timestamp = DateTime.now().microsecondsSinceEpoch.toRadixString(36);
-    final random =
-        (DateTime.now().microsecond * 1000 + DateTime.now().millisecond)
-            .toRadixString(36);
-    final uid = '$timestamp$random';
-    return uid.substring(
-      0,
-      uid.length < 12 ? uid.length : 12,
-    ); // Match nanoid-like max length without range errors
+    _uidCounter = (_uidCounter + 1) & 0x7FFFFFFFFFFFFFFF;
+    return 'r${_uidCounter.toRadixString(16).padLeft(11, '0')}';
   }
 
   /// Validate bindings don't contain null values

--- a/packages/knex_dart/lib/src/raw.dart
+++ b/packages/knex_dart/lib/src/raw.dart
@@ -141,8 +141,8 @@ class Raw {
 
   /// Generate a unique ID for this query.
   String _generateUid() {
-    _uidCounter = (_uidCounter + 1) & 0x7FFFFFFFFFFFFFFF;
-    return 'r${_uidCounter.toRadixString(16).padLeft(11, '0')}';
+    _uidCounter = (_uidCounter + 1) & 0x7FFFFFFF;
+    return 'r${_uidCounter.toRadixString(16).padLeft(8, '0')}';
   }
 
   /// Validate bindings don't contain null values

--- a/packages/knex_dart/pubspec.yaml
+++ b/packages/knex_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: knex_dart
 description: A Dart SQL query builder inspired by Knex.js. Use driver packages (knex_dart_postgres, knex_dart_mysql, knex_dart_sqlite) to connect to databases.
-version: 1.2.0
+version: 1.2.1
 repository: https://github.com/kartikey321/knex-dart
 homepage: https://github.com/kartikey321/knex-dart
 issue_tracker: https://github.com/kartikey321/knex-dart/issues

--- a/packages/knex_dart/test/query/query_compiler_test.dart
+++ b/packages/knex_dart/test/query/query_compiler_test.dart
@@ -22,7 +22,7 @@ void main() {
       expect(sql.sql, 'select * from "users"');
       expect(sql.bindings, []);
       expect(sql.method, 'select');
-      expect(sql.uid?.length, 12);
+      expect(sql.uid, matches(RegExp(r'^q[0-9a-f]{8}$')));
     });
 
     test('Test 2: SELECT with specific columns', () {
@@ -111,8 +111,8 @@ void main() {
       final sql2 = builder.toSQL();
 
       expect(sql1.uid, isNot(equals(sql2.uid)));
-      expect(sql1.uid?.length, 12);
-      expect(sql2.uid?.length, 12);
+      expect(sql1.uid, matches(RegExp(r'^q[0-9a-f]{8}$')));
+      expect(sql2.uid, matches(RegExp(r'^q[0-9a-f]{8}$')));
     });
   });
 
@@ -372,7 +372,9 @@ void main() {
 
     test('MSSQL LIMIT only uses OFFSET/FETCH', () {
       final mssql = MockClient(driverName: 'mssql');
-      final builder = QueryBuilder(mssql).table('users').orderBy('id').limit(10);
+      final builder = QueryBuilder(
+        mssql,
+      ).table('users').orderBy('id').limit(10);
       final sql = builder.toSQL();
 
       expect(

--- a/packages/knex_dart/test/query/query_compiler_test.dart
+++ b/packages/knex_dart/test/query/query_compiler_test.dart
@@ -22,7 +22,7 @@ void main() {
       expect(sql.sql, 'select * from "users"');
       expect(sql.bindings, []);
       expect(sql.method, 'select');
-      expect(sql.uid, matches(RegExp(r'^q[0-9a-f]{8}$')));
+      expect(sql.uid, matches(RegExp(r'^q[0-9a-f]{14}$')));
     });
 
     test('Test 2: SELECT with specific columns', () {
@@ -111,8 +111,8 @@ void main() {
       final sql2 = builder.toSQL();
 
       expect(sql1.uid, isNot(equals(sql2.uid)));
-      expect(sql1.uid, matches(RegExp(r'^q[0-9a-f]{8}$')));
-      expect(sql2.uid, matches(RegExp(r'^q[0-9a-f]{8}$')));
+      expect(sql1.uid, matches(RegExp(r'^q[0-9a-f]{14}$')));
+      expect(sql2.uid, matches(RegExp(r'^q[0-9a-f]{14}$')));
     });
   });
 

--- a/packages/knex_dart/test/query/uid_generation_test.dart
+++ b/packages/knex_dart/test/query/uid_generation_test.dart
@@ -1,0 +1,32 @@
+import 'package:knex_dart/knex_dart.dart';
+import 'package:test/test.dart';
+
+import '../mocks/mock_client.dart';
+
+void main() {
+  group('compiled SQL uid generation', () {
+    test('QueryCompiler generates monotonic JS-safe query ids', () {
+      final knex = KnexQuery.forDialect(KnexDialect.sqlite);
+
+      final first = knex.from('users').select(['id']).toSQL().uid;
+      final second = knex.from('users').select(['name']).toSQL().uid;
+
+      expect(first, matches(RegExp(r'^q[0-9a-f]{8}$')));
+      expect(second, matches(RegExp(r'^q[0-9a-f]{8}$')));
+      expect(_uidValue(second!), greaterThan(_uidValue(first!)));
+    });
+
+    test('Raw generates monotonic JS-safe raw ids', () {
+      final client = MockClient();
+
+      final first = Raw(client).set('select 1').toSQL().uid;
+      final second = Raw(client).set('select 2').toSQL().uid;
+
+      expect(first, matches(RegExp(r'^r[0-9a-f]{8}$')));
+      expect(second, matches(RegExp(r'^r[0-9a-f]{8}$')));
+      expect(_uidValue(second!), greaterThan(_uidValue(first!)));
+    });
+  });
+}
+
+int _uidValue(String uid) => int.parse(uid.substring(1), radix: 16);

--- a/packages/knex_dart/test/query/uid_generation_test.dart
+++ b/packages/knex_dart/test/query/uid_generation_test.dart
@@ -11,8 +11,8 @@ void main() {
       final first = knex.from('users').select(['id']).toSQL().uid;
       final second = knex.from('users').select(['name']).toSQL().uid;
 
-      expect(first, matches(RegExp(r'^q[0-9a-f]{8}$')));
-      expect(second, matches(RegExp(r'^q[0-9a-f]{8}$')));
+      expect(first, matches(RegExp(r'^q[0-9a-f]{14}$')));
+      expect(second, matches(RegExp(r'^q[0-9a-f]{14}$')));
       expect(_uidValue(second!), greaterThan(_uidValue(first!)));
     });
 
@@ -22,8 +22,8 @@ void main() {
       final first = Raw(client).set('select 1').toSQL().uid;
       final second = Raw(client).set('select 2').toSQL().uid;
 
-      expect(first, matches(RegExp(r'^r[0-9a-f]{8}$')));
-      expect(second, matches(RegExp(r'^r[0-9a-f]{8}$')));
+      expect(first, matches(RegExp(r'^r[0-9a-f]{14}$')));
+      expect(second, matches(RegExp(r'^r[0-9a-f]{14}$')));
       expect(_uidValue(second!), greaterThan(_uidValue(first!)));
     });
   });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ workspace:
   - packages/knex_dart_capabilities
   - packages/knex_dart_lint
   - integrations/knex_dart_otel
+  - benchmarks
 
 dev_dependencies:
   melos: ^7.0.0


### PR DESCRIPTION
 ## Summary

  - Add OTel span attribute verification tests for `knex_dart_otel`
  - Add benchmark workspace package for SQL generation, SQLite live execution, and API cost matrix runs
  - Optimize core query compilation and SQLite wrapper hot paths
  - Add real SDK SQLite OTel example app
  - Prepare `knex_dart`, `knex_dart_sqlite`, and `knex_dart_otel` for pub.dev publishing

  ## Release Prep

  - Bump `knex_dart` to `1.2.1`
  - Bump `knex_dart_sqlite` to `0.2.1`
  - Add/expand changelogs
  - Add missing `knex_dart_otel` license
  - Document core `QueryInterceptor` usage in the README
  - Tighten CI publishing to tag-only pub.dev trusted publishing

  ## Validation

  - `dart pub get`
  - `dart analyze --fatal-warnings packages/knex_dart/lib drivers/knex_dart_sqlite/lib integrations/
  knex_dart_otel/lib integrations/knex_dart_otel/test benchmarks .github`
  - `dart test integrations/knex_dart_otel/test`
  - `dart test drivers/knex_dart_sqlite/test`
  - `dart pub publish --dry-run` for:
    - `packages/knex_dart`
    - `drivers/knex_dart_sqlite`
    - `integrations/knex_dart_otel`

  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a benchmarks workspace with multi-dialect runner, reporters, CLI tools, and a live SQLite benchmark; added an OpenTelemetry-backed SQLite example app.

* **Bug Fixes / Performance**
  * SQL compilation hot-path optimizations and reduced SQLite driver wrapper overhead; improved error stack behavior preservation.

* **Documentation**
  * Updated docs and changelogs with interceptor usage and OTel example instructions.

* **Chores**
  * CI publish flow now triggers on tags and uses dry-run publishes; ignored benchmark results and added Makefile targets for benchmarks.

* **Tests**
  * New tests for UID monotonicity and OTel span attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->