### PR TITLE
Feat/sqlite watch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,14 @@ jobs:
           PG_DATABASE: knex_test
           PG_USER: knex
           PG_PASSWORD: knex
+      - name: Run PostgreSQL doc snippets
+        run: dart run tool/check_doc_snippets.dart --mode=run --scope=postgres
+        env:
+          PG_HOST: localhost
+          PG_PORT: 5432
+          PG_DATABASE: knex_test
+          PG_USER: knex
+          PG_PASSWORD: knex
 
   # ════════════════════════════════════════════════════════════════════════════
   # 9 · MySQL  ·  Linux + Docker service
@@ -442,6 +450,14 @@ jobs:
       - name: Run MySQL tests
         working-directory: drivers/knex_dart_mysql
         run: dart test --tags=mysql && dart test test/pool test/mocks
+        env:
+          MYSQL_HOST: localhost
+          MYSQL_PORT: 3306
+          MYSQL_DATABASE: knex_test
+          MYSQL_USER: knex
+          MYSQL_PASSWORD: knex
+      - name: Run MySQL doc snippets
+        run: dart run tool/check_doc_snippets.dart --mode=run --scope=mysql
         env:
           MYSQL_HOST: localhost
           MYSQL_PORT: 3306
@@ -496,6 +512,14 @@ jobs:
           dart test test/integration/mssql_test.dart --concurrency=1
           dart test test/integration/mssql_pipeline_test.dart --concurrency=1
           dart test test/integration/schema_api_integration_test.dart --concurrency=1
+        env:
+          MSSQL_HOST: localhost
+          MSSQL_PORT: "1433"
+          MSSQL_DATABASE: knex_test
+          MSSQL_USER: sa
+          MSSQL_PASSWORD: "Knex_Test1!"
+      - name: Run MSSQL doc snippets
+        run: dart run tool/check_doc_snippets.dart --mode=run --scope=mssql
         env:
           MSSQL_HOST: localhost
           MSSQL_PORT: "1433"
@@ -650,6 +674,8 @@ jobs:
           dart pub get
       - name: Check doc snippets
         run: dart run tool/check_doc_snippets.dart
+      - name: Run local doc snippets
+        run: dart run tool/check_doc_snippets.dart --mode=run --scope=local
 
   # ════════════════════════════════════════════════════════════════════════════
   # 16 · Playground generated assets

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ playground/dist/
 # Generated playground Dart-live artifacts (platform-dependent, built at deploy time)
 playground/public/dart-live/knex_dart.dill
 playground/public/dart-live/knex_dart_packages.bin
+
+# Reference clones (temporary, for inspiration only — delete after use)
+reference/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help db-up db-down test-all test-postgres test-mysql test-sqlite test-duckdb test-mssql test-turso test-bigquery test-d1 test-snowflake test-unit analyze coverage bench-sql bench-sqlite bench-matrix bench-all example-otel-sqlite check-docs update-versions
+.PHONY: help db-up db-down test-all test-postgres test-mysql test-sqlite test-duckdb test-mssql test-turso test-bigquery test-d1 test-snowflake test-unit analyze coverage bench-sql bench-sqlite bench-matrix bench-all example-otel-sqlite check-docs check-docs-runtime check-docs-runtime-postgres check-docs-runtime-mysql check-docs-runtime-mssql update-versions
 
 # Local development only — not used in CI.
 # CI uses `dart test --tags=<driver>` directly against GitHub Actions service containers.
@@ -52,6 +52,18 @@ analyze: ## Run static analysis across workspace
 
 check-docs: ## Validate doc snippets and README version constraints
 	dart run tool/check_doc_snippets.dart
+
+check-docs-runtime: ## Execute runnable local doc snippets
+	dart run tool/check_doc_snippets.dart --mode=run --scope=local
+
+check-docs-runtime-postgres: ## Execute runnable PostgreSQL doc snippets
+	dart run tool/check_doc_snippets.dart --mode=run --scope=postgres
+
+check-docs-runtime-mysql: ## Execute runnable MySQL doc snippets
+	dart run tool/check_doc_snippets.dart --mode=run --scope=mysql
+
+check-docs-runtime-mssql: ## Execute runnable MSSQL doc snippets
+	dart run tool/check_doc_snippets.dart --mode=run --scope=mssql
 
 update-versions: ## Sync README version constraints from pubspec.yaml (run after version bumps)
 	dart run tool/update_readme_versions.dart

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help db-up db-down test-all test-postgres test-mysql test-sqlite test-duckdb test-mssql test-turso test-bigquery test-d1 test-snowflake test-unit analyze coverage bench-sql bench-sqlite bench-matrix bench-all example-otel-sqlite check-docs check-docs-runtime check-docs-runtime-postgres check-docs-runtime-mysql check-docs-runtime-mssql update-versions
+.PHONY: help db-up db-down test-all test-postgres test-mysql test-sqlite test-duckdb test-mssql test-turso test-bigquery test-d1 test-snowflake test-unit analyze coverage bench-sql bench-sqlite bench-matrix bench-all example-otel-sqlite check-docs check-docs-runtime check-docs-runtime-postgres check-docs-runtime-mysql check-docs-runtime-mssql snapshot-docs snapshot-docs-postgres snapshot-docs-mysql snapshot-docs-mssql update-versions
 
 # Local development only — not used in CI.
 # CI uses `dart test --tags=<driver>` directly against GitHub Actions service containers.
@@ -64,6 +64,18 @@ check-docs-runtime-mysql: ## Execute runnable MySQL doc snippets
 
 check-docs-runtime-mssql: ## Execute runnable MSSQL doc snippets
 	dart run tool/check_doc_snippets.dart --mode=run --scope=mssql
+
+snapshot-docs: ## Auto-generate expect_stdout in local doc:run directives
+	dart run tool/check_doc_snippets.dart --mode=snapshot --scope=local
+
+snapshot-docs-postgres: ## Auto-generate expect_stdout in PostgreSQL doc:run directives
+	dart run tool/check_doc_snippets.dart --mode=snapshot --scope=postgres
+
+snapshot-docs-mysql: ## Auto-generate expect_stdout in MySQL doc:run directives
+	dart run tool/check_doc_snippets.dart --mode=snapshot --scope=mysql
+
+snapshot-docs-mssql: ## Auto-generate expect_stdout in MSSQL doc:run directives
+	dart run tool/check_doc_snippets.dart --mode=snapshot --scope=mssql
 
 update-versions: ## Sync README version constraints from pubspec.yaml (run after version bumps)
 	dart run tool/update_readme_versions.dart

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ await db.destroy();
 
 ### SQLite
 
+<!-- doc:run scope=local expect_stdout='Alice' -->
 ```dart
 import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
 
@@ -100,7 +101,9 @@ await db.executeSchema(
 );
 
 await db.insert(db('users').insert({'name': 'Alice'}));
-await db.destroy();
+final rows = await db.select(db('users').select(['name']));
+print(rows.first['name']);
+await db.close();
 ```
 
 ### DuckDB (OLAP / Browser WASM)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Add the driver for your database — it pulls in `knex_dart` automatically:
 dependencies:
   knex_dart_postgres: ^0.3.1   # PostgreSQL
   # knex_dart_mysql: ^0.3.1    # MySQL
-  # knex_dart_sqlite: ^0.3.0   # SQLite
+  # knex_dart_sqlite: ^0.4.0   # SQLite
   # knex_dart_duckdb: ^0.2.1   # DuckDB (OLAP / browser WASM)
 ```
 
@@ -58,7 +58,7 @@ For SQL generation only (no live connection):
 
 ```yaml
 dependencies:
-  knex_dart: ^1.2.1
+  knex_dart: ^1.3.0
   knex_dart_capabilities: ^0.3.0
 ```
 

--- a/benchmarks/pubspec.yaml
+++ b/benchmarks/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  knex_dart: ^1.2.1
-  knex_dart_sqlite: ^0.3.0
+  knex_dart: ^1.3.0
+  knex_dart_sqlite: ^0.4.0
   knex_dart_otel: ^0.1.0
   dartastic_opentelemetry_api: ^0.9.0
   sqlite3: ^2.4.0

--- a/docs/site/content/connections/streaming.md
+++ b/docs/site/content/connections/streaming.md
@@ -1,6 +1,6 @@
 ---
 title: Streaming
-description: Stream large result sets row-by-row with streamQuery() for memory-efficient processing
+description: Stream large result sets row-by-row and use SQLite watch() for reactive query updates
 ---
 
 # Streaming
@@ -78,7 +78,7 @@ await for (final row in stream) {
 }
 
 print('Done — $count events processed');
-await db.destroy();
+await db.close();
 ```
 
 ## SQLite Example
@@ -137,6 +137,62 @@ try {
 ```
 
 Any database error during streaming will throw inside the `await for` loop and can be caught normally.
+
+## Reactive Queries on SQLite
+
+SQLite also exposes `watch()` for a different use case: re-run a query whenever
+one of its source tables changes.
+
+<!-- doc:run scope=local expect_stdout='Pending todos: 1' -->
+```dart
+import 'dart:async';
+
+import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
+
+final db = await KnexSQLite.connect(filename: ':memory:');
+await db.executeSchema((schema) {
+  schema.createTable('todos', (t) {
+    t.increments('id');
+    t.string('title');
+    t.boolean('done');
+  });
+});
+
+final initial = Completer<void>();
+final completer = Completer<List<Map<String, dynamic>>>();
+var sawInitial = false;
+
+final sub = db.watch(
+  db('todos').where('done', '=', false).orderBy('id'),
+).listen((rows) {
+  if (!sawInitial) {
+    sawInitial = true;
+    if (!initial.isCompleted) initial.complete();
+    return;
+  }
+  if (!completer.isCompleted) completer.complete(rows);
+});
+
+await initial.future;
+await db.insert(
+  db('todos').insert({'title': 'Ship docs', 'done': false}),
+);
+
+final rows = await completer.future;
+print('Pending todos: ${rows.length}');
+await sub.cancel();
+await db.close();
+```
+
+`watch()` is SQLite-specific today. It emits once immediately on subscribe, then
+re-emits after relevant writes commit.
+
+Notes:
+
+- It tracks the base table plus joined tables in the query.
+- It does not track subquery-backed primary tables.
+- Schema changes do not trigger re-emits.
+- SQLite's `UPDATE_HOOK` does not fire for `DELETE` without `WHERE` or for `WITHOUT ROWID` tables.
 
 ## Streaming Inside a Transaction
 

--- a/docs/site/content/database-support.md
+++ b/docs/site/content/database-support.md
@@ -219,15 +219,24 @@ final db = await KnexMssql.connect(
   password: Platform.environment['MSSQL_PASSWORD'] ?? 'Knex_Test1!',
 );
 
-await db.rawSql('CREATE TABLE #doc_users (name NVARCHAR(50))');
-await db.rawSql("INSERT INTO #doc_users (name) VALUES ('Alice')");
+await db.executeSchema((schema) {
+  schema.dropTableIfExists('doc_users_snippet');
+  schema.createTable('doc_users_snippet', (table) {
+    table.string('name', 50).notNullable();
+  });
+});
 
-final rows = await db.select(
-  db('#doc_users').select(['name']),
+await db.insert(
+  db('doc_users_snippet').insert({'name': 'Alice'}),
 );
 
+final rows = await db.select(db('doc_users_snippet').select(['name']));
+
 print(rows.first['name']);
-await db.destroy();
+await db.executeSchema((schema) {
+  schema.dropTableIfExists('doc_users_snippet');
+});
+await db.close();
 ```
 
 **SQL Server-specific features:**

--- a/docs/site/content/database-support.md
+++ b/docs/site/content/database-support.md
@@ -13,7 +13,7 @@ Each database is a separate driver package. Install only what you need.
 |---|---|---|---|
 | PostgreSQL | [`knex_dart_postgres`](https://pub.dev/packages/knex_dart_postgres) | TCP | Pooled, savepoints, RETURNING |
 | MySQL | [`knex_dart_mysql`](https://pub.dev/packages/knex_dart_mysql) | TCP | Pooled, savepoints |
-| SQLite | [`knex_dart_sqlite`](https://pub.dev/packages/knex_dart_sqlite) | FFI | File + in-memory, savepoints |
+| SQLite | [`knex_dart_sqlite`](https://pub.dev/packages/knex_dart_sqlite) | FFI / WASM | File + in-memory, savepoints, watch(), web storage modes |
 | DuckDB | [`knex_dart_duckdb`](https://pub.dev/packages/knex_dart_duckdb) | FFI / WASM | OLAP, native + browser |
 | SQL Server | [`knex_dart_mssql`](https://pub.dev/packages/knex_dart_mssql) | FreeTDS | Windows/Linux/macOS |
 | Google BigQuery | [`knex_dart_bigquery`](https://pub.dev/packages/knex_dart_bigquery) | HTTP | REST API |
@@ -25,21 +25,30 @@ Each database is a separate driver package. Install only what you need.
 
 ## PostgreSQL
 
+<!-- doc:run scope=postgres expect_stdout='Alice' -->
 ```dart
+import 'dart:io';
+
 import 'package:knex_dart_postgres/knex_dart_postgres.dart';
 
 final db = await KnexPostgres.connect(
-  host: 'localhost',
-  port: 5432,
-  database: 'myapp',
-  username: 'user',
-  password: 'pass',
+  host: Platform.environment['PG_HOST'] ?? 'localhost',
+  port: int.parse(Platform.environment['PG_PORT'] ?? '5432'),
+  database: Platform.environment['PG_DATABASE'] ?? 'knex_test',
+  username: Platform.environment['PG_USER'] ?? 'knex',
+  password: Platform.environment['PG_PASSWORD'] ?? 'knex',
+);
+
+await db.rawSql('create temporary table doc_users (name text)');
+await db.insert(
+  db('doc_users').insert({'name': 'Alice'}),
 );
 
 final rows = await db.select(
-  db('users').where('active', '=', true),
+  db('doc_users').select(['name']),
 );
 
+print(rows.first['name']);
 await db.destroy();
 ```
 
@@ -66,21 +75,30 @@ final db = await KnexPostgres.connect(
 
 ## MySQL
 
+<!-- doc:run scope=mysql expect_stdout='Alice' -->
 ```dart
+import 'dart:io';
+
 import 'package:knex_dart_mysql/knex_dart_mysql.dart';
 
 final db = await KnexMySQL.connect(
-  host: 'localhost',
-  port: 3306,
-  database: 'myapp',
-  user: 'user',
-  password: 'pass',
+  host: Platform.environment['MYSQL_HOST'] ?? 'localhost',
+  port: int.parse(Platform.environment['MYSQL_PORT'] ?? '3306'),
+  database: Platform.environment['MYSQL_DATABASE'] ?? 'knex_test',
+  user: Platform.environment['MYSQL_USER'] ?? 'knex',
+  password: Platform.environment['MYSQL_PASSWORD'] ?? 'knex',
+);
+
+await db.rawSql('create temporary table doc_users (name varchar(50))');
+await db.insert(
+  db('doc_users').insert({'name': 'Alice'}),
 );
 
 final rows = await db.select(
-  db('users').where('active', '=', true),
+  db('doc_users').select(['name']),
 );
 
+print(rows.first['name']);
 await db.destroy();
 ```
 
@@ -110,16 +128,24 @@ final db = await KnexMySQL.connect(
 import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
 
 // File-based
-final db = await KnexSQLite.connect(filename: 'app.db');
+final fileDb = await KnexSQLite.connect(filename: 'app.db');
 
 // In-memory
-final db = await KnexSQLite.connect(filename: ':memory:');
+final memoryDb = await KnexSQLite.connect(filename: ':memory:');
 
-final rows = await db.select(
-  db('users').where('active', '=', true),
+// Browser/WASM only: automatic storage selection
+final webDb = await KnexSQLite.connect(
+  filename: 'app.db',
+  webStorageMode: 'auto',
 );
 
-await db.destroy();
+final rows = await fileDb.select(
+  fileDb('users').where('active', '=', true),
+);
+
+await fileDb.close();
+await memoryDb.close();
+await webDb.close();
 ```
 
 **SQLite-specific features:**
@@ -128,7 +154,12 @@ await db.destroy();
 - In-memory database support
 - Nested transactions via `SAVEPOINT`
 - Streaming via `Statement.selectCursor()`
+- Reactive `watch()` query streams
+- Browser/WASM storage modes: `memory`, `indexedDb`, `opfs`, `auto`
 - JSON via `json_extract()`
+
+`webStorageMode` is web-only. Passing it to the native sqlite3 driver throws
+`UnsupportedError`.
 
 ---
 
@@ -174,21 +205,28 @@ await db.close();
 
 ## SQL Server (MSSQL)
 
+<!-- doc:run scope=mssql expect_stdout='Alice' -->
 ```dart
+import 'dart:io';
+
 import 'package:knex_dart_mssql/knex_dart_mssql.dart';
 
 final db = await KnexMssql.connect(
-  host: 'localhost',
-  port: '1433',
-  database: 'myapp',
-  username: 'sa',
-  password: 'YourPassword1!',
+  host: Platform.environment['MSSQL_HOST'] ?? 'localhost',
+  port: Platform.environment['MSSQL_PORT'] ?? '1433',
+  database: Platform.environment['MSSQL_DATABASE'] ?? 'knex_test',
+  username: Platform.environment['MSSQL_USER'] ?? 'sa',
+  password: Platform.environment['MSSQL_PASSWORD'] ?? 'Knex_Test1!',
 );
+
+await db.rawSql('CREATE TABLE #doc_users (name NVARCHAR(50))');
+await db.rawSql("INSERT INTO #doc_users (name) VALUES ('Alice')");
 
 final rows = await db.select(
-  db('users').where('active', '=', true),
+  db('#doc_users').select(['name']),
 );
 
+print(rows.first['name']);
 await db.destroy();
 ```
 

--- a/docs/site/content/getting-started/installation.md
+++ b/docs/site/content/getting-started/installation.md
@@ -57,6 +57,11 @@ dart pub add knex_dart_mysql
 dart pub add knex_dart_sqlite
 ```
 
+SQLite runs natively on mobile/desktop/server and also in the browser via
+`sqlite3.wasm`. On web, `KnexSQLite.connect()` can choose persistence with
+`webStorageMode: 'memory' | 'indexedDb' | 'opfs' | 'auto'`. This option is
+web-only; the native sqlite3 driver rejects it.
+
 ### DuckDB (OLAP / Analytics)
 
 ```bash
@@ -127,6 +132,7 @@ This is useful for testing, SQL snapshots, or generating queries to pass to anot
 
 ### With a driver (SQLite example)
 
+<!-- doc:run scope=local expect_stdout='select "id", "name" from "users"' -->
 ```dart
 import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
 
@@ -134,12 +140,13 @@ Future<void> main() async {
   final db = await KnexSQLite.connect(filename: ':memory:');
   print(db('users').select(['id', 'name']).toSQL().sql);
   // select "id", "name" from "users"
-  await db.destroy();
+  await db.close();
 }
 ```
 
 ### Query builder only
 
+<!-- doc:run scope=local expect_stdout='select "id", "name" from "users"' -->
 ```dart
 import 'package:knex_dart/knex_dart.dart';
 import 'package:knex_dart_capabilities/knex_dart_capabilities.dart';

--- a/docs/site/content/getting-started/quick-start.md
+++ b/docs/site/content/getting-started/quick-start.md
@@ -60,6 +60,17 @@ import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
 final db = await KnexSQLite.connect(filename: ':memory:');
 ```
 
+Browser/WASM example:
+
+```dart
+final db = await KnexSQLite.connect(
+  filename: 'app.db',
+  webStorageMode: 'auto',
+);
+```
+
+`webStorageMode` is only for web/WASM. On native SQLite, omit it.
+
 ### PostgreSQL
 
 ```dart
@@ -195,7 +206,52 @@ await db.trx((trx) async {
 ## 7) Cleanup
 
 ```dart
-await db.destroy();
+await db.close();
+```
+
+## 8) Reactive SQLite Queries
+
+SQLite can re-run a query whenever one of its source tables changes:
+
+<!-- doc:run scope=local expect_stdout='Active users: 1' -->
+```dart
+import 'dart:async';
+
+import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
+
+final db = await KnexSQLite.connect(filename: ':memory:');
+await db.executeSchema((schema) {
+  schema.createTable('users', (t) {
+    t.increments('id');
+    t.string('name');
+    t.boolean('active');
+  });
+});
+
+final initial = Completer<void>();
+final completer = Completer<List<Map<String, dynamic>>>();
+var sawInitial = false;
+
+final sub = db.watch(
+  db('users').where('active', '=', true).orderBy('name'),
+).listen((rows) {
+  if (!sawInitial) {
+    sawInitial = true;
+    if (!initial.isCompleted) initial.complete();
+    return;
+  }
+  if (!completer.isCompleted) completer.complete(rows);
+});
+
+await initial.future;
+await db.insert(
+  db('users').insert({'name': 'Alice', 'active': true}),
+);
+
+final rows = await completer.future;
+print('Active users: ${rows.length}');
+await sub.cancel();
+await db.close();
 ```
 
 ## Next Steps
@@ -204,5 +260,5 @@ await db.destroy();
 - [WHERE Clauses](/query-building/where-clauses) — All 29 filtering methods
 - [Joins](/query-building/joins) — INNER, LEFT, RIGHT, FULL OUTER, LATERAL
 - [Transactions](/query-building/transactions) — Atomic operations and nested savepoints
-- [Streaming](/connections/streaming) — Memory-efficient large result sets
+- [Streaming](/connections/streaming) — Row streaming and SQLite watch queries
 - [Examples](/examples/basic-queries)

--- a/docs/site/content/index.md
+++ b/docs/site/content/index.md
@@ -22,11 +22,11 @@ A powerful, flexible SQL query builder for Dart, ported from **[Knex.js](https:/
 - ✅ **Schema Builder** — createTable, alterTable, dropTable, foreign keys, indexes
 - ✅ **Migrations** — code-first, SQL-directory, and JSON-schema sources
 - ✅ **Connection Pooling** — built-in pool for PostgreSQL and MySQL
-- ✅ **Streaming** — `streamQuery()` for memory-efficient large result sets
+- ✅ **Streaming** — `streamQuery()` for large result sets and SQLite `watch()` for reactive queries
 - ✅ **Nested Transactions** — savepoint-based nesting on all drivers
 - ✅ **OpenTelemetry** — optional driver-wrapper spans and `db.client.operation.duration` metrics
 - ✅ **Browser Playground** — Dart LSP diagnostics, hover, auto-imports, and embedded SQL execution
-- ✅ **Web / WASM** — DuckDB runs in Chrome/headless browser via dart_duckdb WASM
+- ✅ **Web / WASM** — DuckDB and SQLite run in the browser via WASM
 - ✅ **591+ Tests Passing** — comprehensive coverage with >85% line coverage
 - ✅ **9 Driver Packages** — install only what you need
 
@@ -36,7 +36,7 @@ A powerful, flexible SQL query builder for Dart, ported from **[Knex.js](https:/
 |---|---|---|
 | PostgreSQL | [`knex_dart_postgres`](https://pub.dev/packages/knex_dart_postgres) | Pooled, savepoints, RETURNING |
 | MySQL | [`knex_dart_mysql`](https://pub.dev/packages/knex_dart_mysql) | Pooled, savepoints |
-| SQLite | [`knex_dart_sqlite`](https://pub.dev/packages/knex_dart_sqlite) | File + in-memory, savepoints |
+| SQLite | [`knex_dart_sqlite`](https://pub.dev/packages/knex_dart_sqlite) | File + in-memory, savepoints, watch(), web/WASM |
 | DuckDB | [`knex_dart_duckdb`](https://pub.dev/packages/knex_dart_duckdb) | OLAP, native + WASM/web |
 | SQL Server | [`knex_dart_mssql`](https://pub.dev/packages/knex_dart_mssql) | FreeTDS-based |
 | Google BigQuery | [`knex_dart_bigquery`](https://pub.dev/packages/knex_dart_bigquery) | HTTP-based |
@@ -83,7 +83,7 @@ final users = await db.select(
     .orderBy('name'),
 );
 
-await db.destroy();
+await db.close();
 ```
 
 Or generate SQL without a connection (for testing or logging):

--- a/docs/site/content/query-building/transactions.md
+++ b/docs/site/content/query-building/transactions.md
@@ -9,7 +9,24 @@ Knex Dart supports database transactions through the `trx()` method on every dri
 
 ## Basic Usage
 
+<!-- doc:run scope=local expect_stdout='2' -->
 ```dart
+import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
+
+final db = await KnexSQLite.connect(filename: ':memory:');
+await db.executeSchema((schema) {
+  schema.createTable('accounts', (t) {
+    t.increments('id');
+    t.string('owner');
+    t.integer('balance');
+  });
+  schema.createTable('ledger', (t) {
+    t.increments('id');
+    t.string('action');
+    t.integer('amount');
+  });
+});
+
 await db.trx((trx) async {
   await trx.insert(
     trx.queryBuilder().table('accounts').insert({'owner': 'Alice', 'balance': 1000}),
@@ -19,6 +36,11 @@ await db.trx((trx) async {
   );
   // Both succeed → automatic COMMIT
 });
+
+final accounts = await db.select(db('accounts'));
+final ledger = await db.select(db('ledger'));
+print(accounts.length + ledger.length);
+await db.close();
 ```
 
 If any statement inside throws, **both** are rolled back automatically — nothing is partially written.
@@ -125,7 +147,10 @@ await db.trx((trx) async { ... });
 
 ### SQLite
 
-Uses `BEGIN` / `COMMIT` / `ROLLBACK` statements directly on the synchronous SQLite connection.
+Uses `BEGIN` / `COMMIT` / `ROLLBACK` statements directly on the SQLite
+connection. Nested `trx()` calls use savepoints, and concurrent top-level
+transactions are serialized so unrelated async callers do not interleave on the
+same SQLite connection.
 
 ```dart
 import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
@@ -133,6 +158,9 @@ import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
 final db = await KnexSQLite.connect(filename: ':memory:');
 await db.trx((trx) async { ... });
 ```
+
+On native SQLite, `watch()` update notifications are buffered until the outer
+transaction commits, so reactive listeners do not see rolled-back writes.
 
 ## Real-World Example: Bank Transfer
 
@@ -191,17 +219,41 @@ Future<void> transfer({
 
 Calling `trx()` inside an already-open transaction creates a **savepoint** instead of a new `BEGIN`. This allows partial rollback without rolling back the entire outer transaction.
 
+<!-- doc:run scope=local expect_stdout='Outer,partial_rollback_demo' -->
 ```dart
+import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
+
+final db = await KnexSQLite.connect(filename: ':memory:');
+await db.executeSchema((schema) {
+  schema.createTable('accounts', (t) {
+    t.integer('id').primary();
+    t.string('owner');
+    t.integer('balance');
+  });
+  schema.createTable('audit_log', (t) {
+    t.increments('id');
+    t.string('action');
+  });
+});
+
 await db.trx((outer) async {
   // Outer insert
   await outer.insert(
-    outer.queryBuilder().table('accounts').insert({'owner': 'Alice', 'balance': 1000}),
+    outer.queryBuilder().table('accounts').insert({
+      'id': 1,
+      'owner': 'Outer',
+      'balance': 1000,
+    }),
   );
 
   try {
     await outer.trx((inner) async {
       await inner.insert(
-        inner.queryBuilder().table('accounts').insert({'owner': 'Bob', 'balance': 500}),
+        inner.queryBuilder().table('accounts').insert({
+          'id': 2,
+          'owner': 'Inner',
+          'balance': 500,
+        }),
       );
       throw Exception('something went wrong');  // inner rolls back to savepoint
     });
@@ -215,6 +267,11 @@ await db.trx((outer) async {
   );
   // COMMIT — only Alice's row and the audit log entry are written
 });
+
+final accountRows = await db.select(db('accounts').select(['owner']).orderBy('id'));
+final auditRows = await db.select(db('audit_log').select(['action']).orderBy('id'));
+print('${accountRows.first['owner']},${auditRows.first['action']}');
+await db.close();
 ```
 
 If the inner exception is **not caught**, it propagates to the outer callback and rolls back everything:

--- a/docs/site/lib/components/playground_link.dart
+++ b/docs/site/lib/components/playground_link.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
+import 'package:knex_dart/src/util/doc_snippet_runtime.dart';
 
 // URL of the deployed playground. Override via PLAYGROUND_URL env var at build time.
 const _playgroundUrl = String.fromEnvironment(
@@ -9,39 +10,11 @@ const _playgroundUrl = String.fromEnvironment(
   defaultValue: 'https://playground.knex.mahawarkartikey.in',
 );
 
-const _boilerplate =
-    "import 'dart:convert';\n"
-    "import 'package:knex_dart/knex_dart.dart';\n"
-    "import 'package:knex_dart_capabilities/knex_dart_capabilities.dart';\n"
-    "\n"
-    "void sql(SqlString s) =>\n"
-    "    print(jsonEncode({'sql': s.sql, 'bindings': s.bindings}));\n"
-    "\n"
-    "void schema(List<Map<String, dynamic>> stmts) {\n"
-    "  for (final s in stmts) {\n"
-    "    print(jsonEncode({\n"
-    "      'sql': s['sql'] as String,\n"
-    "      'bindings': (s['bindings'] as List?)?.cast<dynamic>() ?? [],\n"
-    "    }));\n"
-    "  }\n"
-    "}\n"
-    "\n";
-
-/// Maps a dialect string to its KnexDialect enum literal for the boilerplate.
-String _dialectEnum(String dialect) => switch (dialect) {
-  'sqlite' => 'KnexDialect.sqlite',
-  'mysql' => 'KnexDialect.mysql',
-  _ => 'KnexDialect.postgres',
-};
-
 String _playgroundDialect(String dialect) => switch (dialect) {
   'sqlite' => 'sqlite',
   'mysql' => 'mysql',
   _ => 'postgres',
 };
-
-/// Preamble injected at the top of main() — sets up `db`.
-String _mainPreamble(String dialect) => "  final db = KnexQuery.forDialect(${_dialectEnum(dialect)});\n";
 
 /// Encodes [code] as URL-safe base64 (no padding) for the playground hash.
 String _encode(String code) {
@@ -50,17 +23,13 @@ String _encode(String code) {
 }
 
 /// Builds the full playground URL for a snippet, including the active dialect.
-/// Wraps the snippet in boilerplate if it isn't already a complete program.
 String playgroundUrl(String snippet, {String dialect = 'postgres'}) {
   final playgroundDialect = _playgroundDialect(dialect);
-  String code;
-  if (snippet.contains('void main(')) {
-    code = snippet;
-  } else {
-    // Only inject `final db = ...` if the snippet doesn't already declare it.
-    final preamble = snippet.contains('final db = KnexQuery.forDialect') ? '' : '${_mainPreamble(playgroundDialect)}\n';
-    code = '${_boilerplate}void main() {\n$preamble$snippet\n}';
-  }
+  final code = buildDocSnippetProgram(
+    snippet,
+    target: DocSnippetTarget.playground,
+    dialect: playgroundDialect,
+  );
   final encodedDialect = Uri.encodeComponent(playgroundDialect);
   return '$_playgroundUrl#code=${_encode(code)}&dialect=$encodedDialect';
 }

--- a/docs/site/lib/components/playground_link.dart
+++ b/docs/site/lib/components/playground_link.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 import 'package:jaspr/dom.dart';
 import 'package:jaspr/jaspr.dart';
-import 'package:knex_dart/src/util/doc_snippet_runtime.dart';
+import 'package:knex_dart/knex_dart.dart';
 
 // URL of the deployed playground. Override via PLAYGROUND_URL env var at build time.
 const _playgroundUrl = String.fromEnvironment(

--- a/docs/site/pubspec.yaml
+++ b/docs/site/pubspec.yaml
@@ -9,6 +9,8 @@ dependencies:
   jaspr: ^0.23.1
   jaspr_content: ^0.5.2
   jaspr_router: ^0.8.2
+  knex_dart:
+    path: ../../packages/knex_dart
   syntax_highlight_lite: ^0.0.1
   universal_html: ^2.3.0
 

--- a/drivers/knex_dart_bigquery/pubspec.yaml
+++ b/drivers/knex_dart_bigquery/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  knex_dart: ^1.2.1
+  knex_dart: ^1.3.0
   http: ^1.2.0
 
 dev_dependencies:

--- a/drivers/knex_dart_d1/pubspec.yaml
+++ b/drivers/knex_dart_d1/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  knex_dart: ^1.2.1
+  knex_dart: ^1.3.0
   http: ^1.2.0
 
 dev_dependencies:

--- a/drivers/knex_dart_duckdb/pubspec.yaml
+++ b/drivers/knex_dart_duckdb/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  knex_dart: ^1.2.1
+  knex_dart: ^1.3.0
   dart_duckdb: ^1.4.4
   wasm_ffi: ^2.3.0
   universal_io: ^2.2.2

--- a/drivers/knex_dart_mssql/pubspec.yaml
+++ b/drivers/knex_dart_mssql/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  knex_dart: ^1.2.1
+  knex_dart: ^1.3.0
   mssql_connection: ^3.0.0
   universal_io: ^2.3.1
 

--- a/drivers/knex_dart_mysql/pubspec.yaml
+++ b/drivers/knex_dart_mysql/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  knex_dart: ^1.2.1
+  knex_dart: ^1.3.0
   mysql_client: ^0.0.27
   logging: ^1.2.0
   universal_io: ^2.3.1

--- a/drivers/knex_dart_postgres/pubspec.yaml
+++ b/drivers/knex_dart_postgres/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  knex_dart: ^1.2.1
+  knex_dart: ^1.3.0
   postgres: ^3.4.50
   logging: ^1.2.0
   universal_io: ^2.3.1

--- a/drivers/knex_dart_snowflake/pubspec.yaml
+++ b/drivers/knex_dart_snowflake/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  knex_dart: ^1.2.1
+  knex_dart: ^1.3.0
   http: ^1.2.0
 
 dev_dependencies:

--- a/drivers/knex_dart_sqlite/CHANGELOG.md
+++ b/drivers/knex_dart_sqlite/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.4.0
+
+- Added `watch()` reactive query streams for SQLite based on `UPDATE_HOOK`.
+- Added web/WASM storage mode selection via `webStorageMode` / `storageMode`
+  with `memory`, `indexedDb`, `opfs`, and `auto` modes.
+- Serialized concurrent top-level transactions across native and web clients.
+- Buffered web SQLite update notifications through transaction boundaries to
+  match native `watch()` semantics.
+- Added coverage for concurrent transactions, reactive query behavior, and
+  native/web storage mode handling.
+
 ## 0.3.0
 
 - Added `QueryInterceptor` pipeline support: attach OTel, logging, or custom

--- a/drivers/knex_dart_sqlite/README.md
+++ b/drivers/knex_dart_sqlite/README.md
@@ -9,7 +9,7 @@ SQLite driver for [knex_dart](https://pub.dev/packages/knex_dart) — execute qu
 
 ```yaml
 dependencies:
-  knex_dart_sqlite: ^0.2.0
+  knex_dart_sqlite: ^0.3.0
 ```
 
 ## Usage
@@ -17,11 +17,13 @@ dependencies:
 ```dart
 import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
 
-// File-based database
+// Pick one connection style for your app:
 final db = await KnexSQLite.connect(filename: 'app.db');
-
-// In-memory database
-final db = await KnexSQLite.connect(filename: ':memory:');
+// final db = await KnexSQLite.connect(filename: ':memory:');
+// final db = await KnexSQLite.connect(
+//   filename: 'app.db',
+//   webStorageMode: 'auto', // auto | opfs | indexedDb | memory
+// );
 
 // Schema
 await db.executeSchema(
@@ -61,7 +63,16 @@ await db.trx((trx) async {
   await trx.update(trx('accounts').where('id', '=', 1).update({'balance': 0}));
 });
 
-await db.destroy();
+// Reactive query watching
+final sub = db.watch(
+  db('users').where('active', '=', true).orderBy('name'),
+  debounce: const Duration(milliseconds: 100),
+).listen((rows) {
+  print('Active users changed: ${rows.length}');
+});
+
+await sub.cancel();
+await db.close();
 ```
 
 ## SQLite-specific features
@@ -69,8 +80,14 @@ await db.destroy();
 - `?` positional placeholders
 - Double-quoted identifier quoting
 - In-memory database support (`:memory:`)
+- Browser/WASM storage modes: `memory`, `indexedDb`, `opfs`, `auto`
 - JSON operators via `json_extract()`
 - Nested transactions via savepoints
+- Top-level transaction serialization on SQLite's single connection
+- Reactive `watch()` query streams
+
+`webStorageMode` is only supported on web/WASM. On native SQLite, passing it to
+`connect()` throws `UnsupportedError`.
 
 ## Documentation
 

--- a/drivers/knex_dart_sqlite/README.md
+++ b/drivers/knex_dart_sqlite/README.md
@@ -9,7 +9,7 @@ SQLite driver for [knex_dart](https://pub.dev/packages/knex_dart) — execute qu
 
 ```yaml
 dependencies:
-  knex_dart_sqlite: ^0.3.0
+  knex_dart_sqlite: ^0.4.0
 ```
 
 ## Usage

--- a/drivers/knex_dart_sqlite/lib/src/knex_sqlite.dart
+++ b/drivers/knex_dart_sqlite/lib/src/knex_sqlite.dart
@@ -1,10 +1,92 @@
+import 'dart:async';
+
 import 'package:knex_dart/knex_dart.dart';
+// common.dart (not sqlite3.dart) so this compiles for web too — sqlite3.dart
+// pulls in the FFI implementation with `external` members that dart2js/dart
+// compile js reject. SqliteUpdate is defined in the platform-neutral common.
+import 'package:sqlite3/common.dart' show SqliteUpdate;
 
 import 'sqlite_client.dart'
     if (dart.library.js_interop) 'sqlite_client_web.dart';
 
+/// Returns the set of table names referenced by [query] (primary + joined).
+Set<String> _tablesFrom(QueryBuilder query) {
+  final tables = <String>{};
+  final t = query.tableName;
+  if (t is String) tables.add(t);
+  for (final stmt in query.statements) {
+    if (stmt['grouping'] == 'join') {
+      final joinTable = stmt['table'];
+      if (joinTable is String) {
+        tables.add(joinTable);
+      } else if (joinTable is JoinClause) {
+        tables.add(joinTable.table);
+      }
+    }
+  }
+  return tables;
+}
+
+/// Wraps [source] with a batch-ceiling debounce.
+///
+/// Emits one event after [duration] of silence, OR after [maxCount] events
+/// accumulate — whichever ceiling is hit first. Both are optional; if neither
+/// is set the original stream is returned unchanged.
+Stream<T> _batchDebounce<T>(
+  Stream<T> source, {
+  Duration? duration,
+  int? maxCount,
+}) {
+  if (duration == null && maxCount == null) return source;
+
+  late StreamController<T> controller;
+  StreamSubscription<T>? sub;
+  Timer? timer;
+  int pending = 0;
+  T? last;
+
+  void flush() {
+    timer?.cancel();
+    timer = null;
+    if (pending == 0) return; // nothing buffered — avoid re-emit on close
+    pending = 0;
+    final value = last as T;
+    last = null;
+    controller.add(value);
+  }
+
+  controller = StreamController<T>(
+    onListen: () {
+      sub = source.listen(
+        (event) {
+          last = event;
+          pending++;
+          if (maxCount != null && pending >= maxCount) {
+            flush();
+            return;
+          }
+          if (duration != null) {
+            timer?.cancel();
+            timer = Timer(duration, flush);
+          }
+        },
+        onError: controller.addError,
+        onDone: () {
+          flush(); // emit any pending event before closing
+          controller.close();
+        },
+      );
+    },
+    onCancel: () async {
+      timer?.cancel();
+      await sub?.cancel();
+    },
+  );
+  return controller.stream;
+}
+
 /// SQLite-specific Knex wrapper.
-class KnexSQLite {
+class KnexSQLite with WatchableClient {
   final SQLiteClient _client;
   final KnexInterceptorPipeline _pipeline;
 
@@ -114,6 +196,71 @@ class KnexSQLite {
     // signature; connection is ignored — SQLite is single-connection.
     return _client.streamQuery(null, compiled.sql, compiled.bindings);
   });
+
+  /// Watches [query] and re-emits results whenever any of its source tables change.
+  ///
+  /// Emits the current result set immediately on subscription, then re-emits
+  /// after each relevant write.
+  ///
+  /// [debounce] sets the silence window before a re-query is triggered.
+  /// [maxPendingWrites] sets the write-count ceiling — a re-query fires as soon
+  /// as this many writes accumulate, even if [debounce] has not elapsed.
+  /// When both are set, whichever ceiling is hit first wins.
+  ///
+  /// Note: SQLite's UPDATE_HOOK does not fire for `DELETE` without a `WHERE`
+  /// clause or for `WITHOUT ROWID` tables.
+  @override
+  Stream<List<Map<String, dynamic>>> watch(
+    QueryBuilder query, {
+    Duration? debounce,
+    int? maxPendingWrites,
+  }) {
+    if (_client.isClosed) throw StateError('Cannot watch a closed database.');
+
+    final tables = _tablesFrom(query);
+    final controller = StreamController<List<Map<String, dynamic>>>();
+
+    StreamSubscription<SqliteUpdate>? sub;
+    var cancelled = false;
+    var emitSeq = 0;
+
+    Future<void> emit() async {
+      if (cancelled || controller.isClosed) return;
+      // Stamp this emission; discard result if a newer emit completes first.
+      final seq = ++emitSeq;
+      try {
+        final rows = await select(query);
+        if (seq == emitSeq && !cancelled && !controller.isClosed) {
+          controller.add(rows);
+        }
+      } catch (e, st) {
+        if (!cancelled && !controller.isClosed) controller.addError(e, st);
+      }
+    }
+
+    controller.onListen = () {
+      // Emit current results immediately after the listener attaches.
+      Future.microtask(emit);
+
+      Stream<SqliteUpdate> updateStream =
+          _client.updates.where((u) => tables.contains(u.tableName));
+
+      updateStream = _batchDebounce(
+        updateStream,
+        duration: debounce,
+        maxCount: maxPendingWrites,
+      );
+
+      sub = updateStream.listen((_) => emit());
+    };
+
+    controller.onCancel = () async {
+      cancelled = true;
+      await sub?.cancel();
+    };
+
+    return controller.stream;
+  }
 
   /// Run a transaction.
   Future<T> trx<T>(Future<T> Function(KnexSQLiteTransaction tx) callback) =>

--- a/drivers/knex_dart_sqlite/lib/src/knex_sqlite.dart
+++ b/drivers/knex_dart_sqlite/lib/src/knex_sqlite.dart
@@ -111,9 +111,13 @@ class KnexSQLite with WatchableClient {
   /// ```
   static Future<KnexSQLite> connect({
     required String filename,
+    String? webStorageMode,
     List<QueryInterceptor> interceptors = const [],
   }) async {
-    final client = await SQLiteClient.connect(filename: filename);
+    final client = await SQLiteClient.connect(
+      filename: filename,
+      webStorageMode: webStorageMode,
+    );
     return KnexSQLite._(
       client,
       pipeline: KnexInterceptorPipeline(

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client.dart
@@ -12,6 +12,15 @@ class SQLiteClient extends Client {
   /// Depth counter for nested transactions (0 = no active transaction).
   int _transactionDepth = 0;
 
+  /// Per-level update buffers. One entry is pushed per BEGIN/SAVEPOINT and
+  /// popped on COMMIT/ROLLBACK. Events are forwarded to [_updateController]
+  /// only on the outermost COMMIT, preventing watch() from seeing phantom rows
+  /// from uncommitted or rolled-back transactions.
+  final List<List<SqliteUpdate>> _txUpdateStack = [];
+
+  late final StreamController<SqliteUpdate> _updateController;
+  StreamSubscription<SqliteUpdate>? _updatesSub;
+
   /// Prepared statement cache keyed by SQL string.
   ///
   /// Avoids repeated `sqlite3_prepare` calls for identical SQL, which is the
@@ -37,6 +46,7 @@ class SQLiteClient extends Client {
 
     final client = SQLiteClient._(filename, config);
     client._db = sqlite3.open(filename);
+    client._setupUpdateHook();
     return client;
   }
 
@@ -54,6 +64,21 @@ class SQLiteClient extends Client {
   /// Opens the underlying SQLite database file.
   Future<void> initialize() async {
     _db = sqlite3.open(_filename);
+    _setupUpdateHook();
+  }
+
+  void _setupUpdateHook() {
+    // sync: true ensures watch() listeners are notified within the same call
+    // stack as the write, matching Drift's internal dispatch pattern.
+    _updateController = StreamController<SqliteUpdate>.broadcast(sync: true);
+    _updatesSub = _db.updates.listen((update) {
+      if (_updateController.isClosed) return;
+      if (_txUpdateStack.isNotEmpty) {
+        _txUpdateStack.last.add(update);
+      } else {
+        _updateController.add(update);
+      }
+    });
   }
 
   @override
@@ -86,11 +111,22 @@ class SQLiteClient extends Client {
       stmt.dispose();
     }
     _stmtCache.clear();
+    // Cancel before dispose so any in-flight async events from _db.updates
+    // don't reach _updateController after it is closed.
+    await _updatesSub?.cancel();
     _db.dispose();
+    await _updateController.close();
   }
 
   /// Whether the connection is closed.
   bool get isClosed => _isClosed;
+
+  /// Stream of low-level table mutation events from SQLite's UPDATE_HOOK.
+  ///
+  /// Events are buffered while a transaction is active and flushed only on
+  /// top-level COMMIT, so [watch] never sees phantom rows from uncommitted or
+  /// rolled-back writes.
+  Stream<SqliteUpdate> get updates => _updateController.stream;
 
   /// Close the database connection.
   Future<void> close() => destroyPool();
@@ -164,28 +200,41 @@ class SQLiteClient extends Client {
     if (_transactionDepth > 0) {
       final sp = _savepointId();
       _transactionDepth++;
+      _txUpdateStack.add([]);
       _db.execute('SAVEPOINT $sp');
       try {
         final result = await callback(this);
         _db.execute('RELEASE SAVEPOINT $sp');
+        // Merge savepoint's buffered updates into the parent level so they
+        // survive to the outermost COMMIT.
+        final saved = _txUpdateStack.removeLast();
+        _txUpdateStack.last.addAll(saved);
         return result;
       } catch (e, st) {
         try {
           _db.execute('ROLLBACK TO SAVEPOINT $sp');
         } catch (_) {}
+        _txUpdateStack.removeLast(); // discard rolled-back updates
         Error.throwWithStackTrace(e, st);
       } finally {
         _transactionDepth--;
       }
     } else {
       _transactionDepth++;
+      _txUpdateStack.add([]);
       _db.execute('BEGIN');
       try {
         final result = await callback(this);
         _db.execute('COMMIT');
+        // Flush all buffered updates now that the transaction is committed.
+        final committed = _txUpdateStack.removeLast();
+        for (final u in committed) {
+          if (!_updateController.isClosed) _updateController.add(u);
+        }
         return result;
       } catch (e) {
         _db.execute('ROLLBACK');
+        _txUpdateStack.removeLast(); // discard all uncommitted updates
         rethrow;
       } finally {
         _transactionDepth--;

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client.dart
@@ -12,6 +12,12 @@ class SQLiteClient extends Client {
   /// Depth counter for nested transactions (0 = no active transaction).
   int _transactionDepth = 0;
 
+  // SQLite uses a single connection here, so unrelated top-level
+  // transactions must not interleave. We queue only the outermost scopes;
+  // nested transactions within the same logical flow still use savepoints.
+  Future<void> _transactionQueue = Future<void>.value();
+  static final Object _transactionZoneKey = Object();
+
   /// Per-level update buffers. One entry is pushed per BEGIN/SAVEPOINT and
   /// popped on COMMIT/ROLLBACK. Events are forwarded to [_updateController]
   /// only on the outermost COMMIT, preventing watch() from seeing phantom rows
@@ -197,6 +203,28 @@ class SQLiteClient extends Client {
 
   /// Executes [callback] in a transaction/savepoint scope.
   Future<T> trx<T>(Future<T> Function(SQLiteClient trx) callback) async {
+    if (Zone.current[_transactionZoneKey] == true) {
+      return _runTransactionScope(callback);
+    }
+
+    final completer = Completer<T>();
+    _transactionQueue = _transactionQueue.catchError((_) {}).then((_) async {
+      try {
+        final result = await runZoned(
+          () => _runTransactionScope(callback),
+          zoneValues: {_transactionZoneKey: true},
+        );
+        completer.complete(result);
+      } catch (e, st) {
+        completer.completeError(e, st);
+      }
+    });
+    return completer.future;
+  }
+
+  Future<T> _runTransactionScope<T>(
+    Future<T> Function(SQLiteClient trx) callback,
+  ) async {
     if (_transactionDepth > 0) {
       final sp = _savepointId();
       _transactionDepth++;

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client.dart
@@ -3,6 +3,8 @@ import 'package:sqlite3/sqlite3.dart';
 
 import 'package:knex_dart/knex_dart.dart';
 
+import 'sqlite_storage_mode.dart';
+
 /// SQLite database client.
 class SQLiteClient extends Client {
   late Database _db;
@@ -41,6 +43,12 @@ class SQLiteClient extends Client {
   /// This is synchronous because sqlite3 opens local files synchronously.
   static SQLiteClient fromConfig(KnexConfig config) {
     final connection = config.connection;
+    if (connection is Map) {
+      final storageMode = connection['storageMode'];
+      if (storageMode != null) {
+        rejectSQLiteWebStorageModeOnNative(storageMode as String);
+      }
+    }
     final filename = switch (connection) {
       String s => s,
       Map m when m['filename'] is String => m['filename'] as String,
@@ -61,6 +69,7 @@ class SQLiteClient extends Client {
     required String filename,
     String? webStorageMode,
   }) async {
+    rejectSQLiteWebStorageModeOnNative(webStorageMode);
     final config = KnexConfig(
       client: 'sqlite3',
       connection: {'filename': filename},

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client.dart
@@ -57,7 +57,10 @@ class SQLiteClient extends Client {
   }
 
   /// Creates and opens a SQLite client for [filename].
-  static Future<SQLiteClient> connect({required String filename}) async {
+  static Future<SQLiteClient> connect({
+    required String filename,
+    String? webStorageMode,
+  }) async {
     final config = KnexConfig(
       client: 'sqlite3',
       connection: {'filename': filename},

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:knex_dart/knex_dart.dart';
 import 'package:sqlite3/wasm.dart';
 
@@ -10,6 +12,12 @@ class SQLiteClient extends Client {
 
   /// Depth counter for nested transactions (0 = no active transaction).
   int _transactionDepth = 0;
+
+  // SQLite uses a single connection here, so unrelated top-level
+  // transactions must not interleave. We queue only the outermost scopes;
+  // nested transactions within the same logical flow still use savepoints.
+  Future<void> _transactionQueue = Future<void>.value();
+  static final Object _transactionZoneKey = Object();
 
   Future<void>? _initialization;
 
@@ -193,6 +201,28 @@ class SQLiteClient extends Client {
 
   /// Executes [callback] in a transaction/savepoint scope.
   Future<T> trx<T>(Future<T> Function(SQLiteClient trx) callback) async {
+    if (Zone.current[_transactionZoneKey] == true) {
+      return _runTransactionScope(callback);
+    }
+
+    final completer = Completer<T>();
+    _transactionQueue = _transactionQueue.catchError((_) {}).then((_) async {
+      try {
+        final result = await runZoned(
+          () => _runTransactionScope(callback),
+          zoneValues: {_transactionZoneKey: true},
+        );
+        completer.complete(result);
+      } catch (e, st) {
+        completer.completeError(e, st);
+      }
+    });
+    return completer.future;
+  }
+
+  Future<T> _runTransactionScope<T>(
+    Future<T> Function(SQLiteClient trx) callback,
+  ) async {
     final db = await _ensureDb();
 
     if (_transactionDepth > 0) {

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
@@ -5,12 +5,7 @@ import 'package:sqlite3/wasm.dart';
 
 import 'sqlite_storage_mode.dart';
 
-enum SQLiteWebStorageMode {
-  memory,
-  indexedDb,
-  opfs,
-  auto,
-}
+enum SQLiteWebStorageMode { memory, indexedDb, opfs, auto }
 
 /// SQLite database client for web/WASM.
 class SQLiteClient extends Client {
@@ -30,14 +25,16 @@ class SQLiteClient extends Client {
   static final Object _transactionZoneKey = Object();
 
   Future<void>? _initialization;
+  final List<List<SqliteUpdate>> _txUpdateStack = [];
+  late final StreamController<SqliteUpdate> _updateController;
+  StreamSubscription<SqliteUpdate>? _updatesSub;
 
   SQLiteClient._(
     this._filename,
     this._wasmUri,
     this._storageMode,
     KnexConfig config,
-  )
-    : super(config);
+  ) : super(config);
 
   static final Uri _defaultWasmUri = Uri.parse(
     'packages/knex_dart_sqlite/web_assets/sqlite3.wasm',
@@ -139,17 +136,30 @@ class SQLiteClient extends Client {
       return;
     }
     _db = opened;
+    _setupUpdateHook(opened);
+  }
+
+  void _setupUpdateHook(CommonDatabase db) {
+    _updateController = StreamController<SqliteUpdate>.broadcast(sync: true);
+    _updatesSub = db.updates.listen((update) {
+      if (_updateController.isClosed) return;
+      if (_txUpdateStack.isNotEmpty) {
+        _txUpdateStack.last.add(update);
+      } else {
+        _updateController.add(update);
+      }
+    });
   }
 
   Future<VirtualFileSystem> _createFileSystem() async {
     return switch (_storageMode) {
       SQLiteWebStorageMode.memory => InMemoryFileSystem(),
       SQLiteWebStorageMode.indexedDb => await IndexedDbFileSystem.open(
-          dbName: _filename,
-        ),
+        dbName: _filename,
+      ),
       SQLiteWebStorageMode.opfs => await SimpleOpfsFileSystem.loadFromStorage(
-          _filename,
-        ),
+        _filename,
+      ),
       SQLiteWebStorageMode.auto => await _createAutoFileSystem(),
     };
   }
@@ -216,9 +226,13 @@ class SQLiteClient extends Client {
     try {
       await initialize();
     } finally {
+      await _updatesSub?.cancel();
       _db?.dispose();
       _db = null;
       _isClosed = true;
+      if (!_updateController.isClosed) {
+        await _updateController.close();
+      }
     }
   }
 
@@ -227,11 +241,11 @@ class SQLiteClient extends Client {
 
   /// Stream of low-level table mutation events from SQLite's UPDATE_HOOK.
   ///
-  /// Async because the web client initializes lazily; the stream opens once
-  /// the WASM database is ready.
+  /// Events are buffered while a transaction is active and flushed only on
+  /// top-level COMMIT, so watch() behavior matches the native client.
   Stream<SqliteUpdate> get updates async* {
-    final db = await _ensureDb();
-    yield* db.updates;
+    await _ensureDb();
+    yield* _updateController.stream;
   }
 
   /// Close the database connection.
@@ -308,28 +322,38 @@ class SQLiteClient extends Client {
     if (_transactionDepth > 0) {
       final sp = _savepointId();
       _transactionDepth++;
+      _txUpdateStack.add([]);
       db.execute('SAVEPOINT $sp');
       try {
         final result = await callback(this);
         db.execute('RELEASE SAVEPOINT $sp');
+        final saved = _txUpdateStack.removeLast();
+        _txUpdateStack.last.addAll(saved);
         return result;
       } catch (e, st) {
         try {
           db.execute('ROLLBACK TO SAVEPOINT $sp');
         } catch (_) {}
+        _txUpdateStack.removeLast();
         Error.throwWithStackTrace(e, st);
       } finally {
         _transactionDepth--;
       }
     } else {
       _transactionDepth++;
+      _txUpdateStack.add([]);
       db.execute('BEGIN');
       try {
         final result = await callback(this);
         db.execute('COMMIT');
+        final saved = _txUpdateStack.removeLast();
+        for (final update in saved) {
+          _updateController.add(update);
+        }
         return result;
       } catch (e) {
         db.execute('ROLLBACK');
+        _txUpdateStack.removeLast();
         rethrow;
       } finally {
         _transactionDepth--;

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:knex_dart/knex_dart.dart';
 import 'package:sqlite3/wasm.dart';
 
+import 'sqlite_storage_mode.dart';
+
 enum SQLiteWebStorageMode {
   memory,
   indexedDb,
@@ -89,15 +91,13 @@ class SQLiteClient extends Client {
         'SQLite config.connection["storageMode"] must be a String.',
       );
     }
-
+    validateSQLiteWebStorageMode(value);
     return switch (value) {
       'memory' => SQLiteWebStorageMode.memory,
       'indexedDb' => SQLiteWebStorageMode.indexedDb,
       'opfs' => SQLiteWebStorageMode.opfs,
       'auto' => SQLiteWebStorageMode.auto,
-      _ => throw ArgumentError(
-        'Unsupported SQLite web storageMode "$value".',
-      ),
+      _ => throw StateError('Unreachable storageMode "$value".'),
     };
   }
 

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
@@ -3,11 +3,19 @@ import 'dart:async';
 import 'package:knex_dart/knex_dart.dart';
 import 'package:sqlite3/wasm.dart';
 
+enum SQLiteWebStorageMode {
+  memory,
+  indexedDb,
+  opfs,
+  auto,
+}
+
 /// SQLite database client for web/WASM.
 class SQLiteClient extends Client {
   CommonDatabase? _db;
   final String _filename;
   final Uri _wasmUri;
+  final SQLiteWebStorageMode _storageMode;
   bool _isClosed = false;
 
   /// Depth counter for nested transactions (0 = no active transaction).
@@ -21,7 +29,12 @@ class SQLiteClient extends Client {
 
   Future<void>? _initialization;
 
-  SQLiteClient._(this._filename, this._wasmUri, KnexConfig config)
+  SQLiteClient._(
+    this._filename,
+    this._wasmUri,
+    this._storageMode,
+    KnexConfig config,
+  )
     : super(config);
 
   static final Uri _defaultWasmUri = Uri.parse(
@@ -35,10 +48,15 @@ class SQLiteClient extends Client {
   static SQLiteClient fromConfig(KnexConfig config) {
     final connection = config.connection;
     final parsed = switch (connection) {
-      String s => (filename: s, wasmUri: _defaultWasmUri),
+      String s => (
+        filename: s,
+        wasmUri: _defaultWasmUri,
+        storageMode: SQLiteWebStorageMode.memory,
+      ),
       Map m when m['filename'] is String => (
         filename: m['filename'] as String,
         wasmUri: _parseWasmUri(m['wasmUri']),
+        storageMode: _parseStorageMode(m['storageMode']),
       ),
       _ => throw ArgumentError(
         'SQLite config.connection must be a filename String '
@@ -46,7 +64,12 @@ class SQLiteClient extends Client {
       ),
     };
 
-    return SQLiteClient._(parsed.filename, parsed.wasmUri, config);
+    return SQLiteClient._(
+      parsed.filename,
+      parsed.wasmUri,
+      parsed.storageMode,
+      config,
+    );
   }
 
   static Uri _parseWasmUri(Object? value) {
@@ -58,13 +81,44 @@ class SQLiteClient extends Client {
     );
   }
 
+  static SQLiteWebStorageMode _parseStorageMode(Object? value) {
+    if (value == null) return SQLiteWebStorageMode.memory;
+    if (value is SQLiteWebStorageMode) return value;
+    if (value is! String) {
+      throw ArgumentError(
+        'SQLite config.connection["storageMode"] must be a String.',
+      );
+    }
+
+    return switch (value) {
+      'memory' => SQLiteWebStorageMode.memory,
+      'indexedDb' => SQLiteWebStorageMode.indexedDb,
+      'opfs' => SQLiteWebStorageMode.opfs,
+      'auto' => SQLiteWebStorageMode.auto,
+      _ => throw ArgumentError(
+        'Unsupported SQLite web storageMode "$value".',
+      ),
+    };
+  }
+
   /// Creates and opens a SQLite client for [filename].
-  static Future<SQLiteClient> connect({required String filename}) async {
+  static Future<SQLiteClient> connect({
+    required String filename,
+    String? webStorageMode,
+  }) async {
     final config = KnexConfig(
       client: 'sqlite3',
-      connection: {'filename': filename},
+      connection: {
+        'filename': filename,
+        'storageMode': webStorageMode ?? SQLiteWebStorageMode.memory.name,
+      },
     );
-    final client = SQLiteClient._(filename, _defaultWasmUri, config);
+    final client = SQLiteClient._(
+      filename,
+      _defaultWasmUri,
+      _parseStorageMode(webStorageMode),
+      config,
+    );
     await client.initialize();
     return client;
   }
@@ -76,7 +130,8 @@ class SQLiteClient extends Client {
 
   Future<void> _initializeImpl() async {
     final sqlite = await _loadSqlite3();
-    sqlite.registerVirtualFileSystem(InMemoryFileSystem(), makeDefault: true);
+    final fileSystem = await _createFileSystem();
+    sqlite.registerVirtualFileSystem(fileSystem, makeDefault: true);
 
     final opened = sqlite.open(_filename);
     if (_isClosed) {
@@ -84,6 +139,31 @@ class SQLiteClient extends Client {
       return;
     }
     _db = opened;
+  }
+
+  Future<VirtualFileSystem> _createFileSystem() async {
+    return switch (_storageMode) {
+      SQLiteWebStorageMode.memory => InMemoryFileSystem(),
+      SQLiteWebStorageMode.indexedDb => await IndexedDbFileSystem.open(
+          dbName: _filename,
+        ),
+      SQLiteWebStorageMode.opfs => await SimpleOpfsFileSystem.loadFromStorage(
+          _filename,
+        ),
+      SQLiteWebStorageMode.auto => await _createAutoFileSystem(),
+    };
+  }
+
+  Future<VirtualFileSystem> _createAutoFileSystem() async {
+    try {
+      return await SimpleOpfsFileSystem.loadFromStorage(_filename);
+    } on Object {
+      try {
+        return await IndexedDbFileSystem.open(dbName: _filename);
+      } on Object {
+        return InMemoryFileSystem();
+      }
+    }
   }
 
   Future<WasmSqlite3> _loadSqlite3() async {

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
@@ -327,6 +327,7 @@ class SQLiteClient extends Client {
       try {
         final result = await callback(this);
         db.execute('RELEASE SAVEPOINT $sp');
+        await _settleUpdateHookQueue();
         final saved = _txUpdateStack.removeLast();
         _txUpdateStack.last.addAll(saved);
         return result;
@@ -334,6 +335,7 @@ class SQLiteClient extends Client {
         try {
           db.execute('ROLLBACK TO SAVEPOINT $sp');
         } catch (_) {}
+        await _settleUpdateHookQueue();
         _txUpdateStack.removeLast();
         Error.throwWithStackTrace(e, st);
       } finally {
@@ -346,6 +348,7 @@ class SQLiteClient extends Client {
       try {
         final result = await callback(this);
         db.execute('COMMIT');
+        await _settleUpdateHookQueue();
         final saved = _txUpdateStack.removeLast();
         for (final update in saved) {
           _updateController.add(update);
@@ -353,12 +356,17 @@ class SQLiteClient extends Client {
         return result;
       } catch (e) {
         db.execute('ROLLBACK');
+        await _settleUpdateHookQueue();
         _txUpdateStack.removeLast();
         rethrow;
       } finally {
         _transactionDepth--;
       }
     }
+  }
+
+  Future<void> _settleUpdateHookQueue() async {
+    await Future<void>.microtask(() {});
   }
 
   static var _spCount = 0;

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
@@ -137,6 +137,15 @@ class SQLiteClient extends Client {
   /// Whether the connection is closed.
   bool get isClosed => _isClosed;
 
+  /// Stream of low-level table mutation events from SQLite's UPDATE_HOOK.
+  ///
+  /// Async because the web client initializes lazily; the stream opens once
+  /// the WASM database is ready.
+  Stream<SqliteUpdate> get updates async* {
+    final db = await _ensureDb();
+    yield* db.updates;
+  }
+
   /// Close the database connection.
   Future<void> close() => destroyPool();
 

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_storage_mode.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_storage_mode.dart
@@ -1,0 +1,24 @@
+const Set<String> kSQLiteWebStorageModes = {
+  'memory',
+  'indexedDb',
+  'opfs',
+  'auto',
+};
+
+void validateSQLiteWebStorageMode(String value) {
+  if (!kSQLiteWebStorageModes.contains(value)) {
+    throw ArgumentError(
+      'Unsupported SQLite web storageMode "$value". '
+      'Expected one of: memory, indexedDb, opfs, auto.',
+    );
+  }
+}
+
+void rejectSQLiteWebStorageModeOnNative(String? value) {
+  if (value == null) return;
+  validateSQLiteWebStorageMode(value);
+  throw UnsupportedError(
+    'SQLite webStorageMode is only supported on web/WASM. '
+    'Remove webStorageMode when using the native sqlite3 driver.',
+  );
+}

--- a/drivers/knex_dart_sqlite/pubspec.yaml
+++ b/drivers/knex_dart_sqlite/pubspec.yaml
@@ -1,6 +1,6 @@
 name: knex_dart_sqlite
 description: SQLite driver for knex_dart — connect and execute queries against a SQLite database using the knex_dart query builder.
-version: 0.3.0
+version: 0.4.0
 repository: https://github.com/kartikey321/knex-dart
 homepage: https://github.com/kartikey321/knex-dart
 issue_tracker: https://github.com/kartikey321/knex-dart/issues
@@ -17,7 +17,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  knex_dart: ^1.2.1
+  knex_dart: ^1.3.0
   sqlite3: ^2.4.0
   sqlite3_web: ^0.3.0
   logging: ^1.2.0

--- a/drivers/knex_dart_sqlite/test/sqlite_trx_test.dart
+++ b/drivers/knex_dart_sqlite/test/sqlite_trx_test.dart
@@ -6,6 +6,7 @@ import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
 import 'package:test/test.dart';
 
 const _table = 'trx_test';
+const _isWeb = bool.fromEnvironment('dart.library.js_interop');
 
 Future<KnexSQLite> _open() => KnexSQLite.connect(filename: ':memory:');
 
@@ -80,7 +81,9 @@ void main() {
 
         await expectLater(
           outer.trx((inner) async {
-            await inner.insert(inner(_table).insert({'id': 11, 'name': 'Inner'}));
+            await inner.insert(
+              inner(_table).insert({'id': 11, 'name': 'Inner'}),
+            );
             throw Exception('inner failure');
           }),
           throwsA(isA<Exception>()),
@@ -108,24 +111,31 @@ void main() {
 
     // ── 6. Inner and outer both roll back ─────────────────────────────────────
 
-    test('nested trx: inner and outer both roll back — nothing committed', () async {
-      await expectLater(
-        db.trx((outer) async {
-          await outer.insert(outer(_table).insert({'id': 30, 'name': 'Outer'}));
-          try {
-            await outer.trx((inner) async {
-              await inner.insert(inner(_table).insert({'id': 31, 'name': 'Inner'}));
-              throw Exception('inner');
-            });
-          } catch (_) {}
-          throw Exception('outer');
-        }),
-        throwsA(isA<Exception>()),
-      );
+    test(
+      'nested trx: inner and outer both roll back — nothing committed',
+      () async {
+        await expectLater(
+          db.trx((outer) async {
+            await outer.insert(
+              outer(_table).insert({'id': 30, 'name': 'Outer'}),
+            );
+            try {
+              await outer.trx((inner) async {
+                await inner.insert(
+                  inner(_table).insert({'id': 31, 'name': 'Inner'}),
+                );
+                throw Exception('inner');
+              });
+            } catch (_) {}
+            throw Exception('outer');
+          }),
+          throwsA(isA<Exception>()),
+        );
 
-      final rows = await db.select(db(_table).select(['*']));
-      expect(rows, isEmpty);
-    });
+        final rows = await db.select(db(_table).select(['*']));
+        expect(rows, isEmpty);
+      },
+    );
 
     // ── 7. Two separate in-memory instances are isolated ─────────────────────
 
@@ -158,33 +168,32 @@ void main() {
       final db2 = await _open();
       await db2.close();
 
-      await expectLater(
-        db2.rawSql('SELECT 1'),
-        throwsA(isA<StateError>()),
-      );
+      await expectLater(db2.rawSql('SELECT 1'), throwsA(isA<StateError>()));
     });
 
     // ── 10. Concurrent top-level transactions are serialized ──────────────────
 
-    test('concurrent top-level trx calls are serialized — no interleaving',
-        () async {
-      // Fire two trx() calls without awaiting the first.
-      // If serialization is broken, the second BEGIN would race with the first,
-      // producing a "cannot start a transaction within a transaction" error.
-      final f1 = db.trx((tx) async {
-        await tx.insert(tx(_table).insert({'id': 40, 'name': 'Concurrent1'}));
-      });
-      final f2 = db.trx((tx) async {
-        await tx.insert(tx(_table).insert({'id': 41, 'name': 'Concurrent2'}));
-      });
+    test(
+      'concurrent top-level trx calls are serialized — no interleaving',
+      () async {
+        // Fire two trx() calls without awaiting the first.
+        // If serialization is broken, the second BEGIN would race with the first,
+        // producing a "cannot start a transaction within a transaction" error.
+        final f1 = db.trx((tx) async {
+          await tx.insert(tx(_table).insert({'id': 40, 'name': 'Concurrent1'}));
+        });
+        final f2 = db.trx((tx) async {
+          await tx.insert(tx(_table).insert({'id': 41, 'name': 'Concurrent2'}));
+        });
 
-      await Future.wait([f1, f2]);
+        await Future.wait([f1, f2]);
 
-      final rows = await db.select(db(_table).select(['*']));
-      expect(rows, hasLength(2));
-      final names = rows.map((r) => r['name']).toSet();
-      expect(names, containsAll(['Concurrent1', 'Concurrent2']));
-    });
+        final rows = await db.select(db(_table).select(['*']));
+        expect(rows, hasLength(2));
+        final names = rows.map((r) => r['name']).toSet();
+        expect(names, containsAll(['Concurrent1', 'Concurrent2']));
+      },
+    );
 
     // ── 11. Failed trx does not block the queue ───────────────────────────────
 
@@ -207,41 +216,38 @@ void main() {
 
     // ── 12. webStorageMode must fail fast on native ───────────────────────────
 
-    test('connect() with webStorageMode throws UnsupportedError on native',
-        () async {
-      await expectLater(
-        KnexSQLite.connect(
-          filename: ':memory:',
-          webStorageMode: 'indexedDb',
-        ),
-        throwsA(isA<UnsupportedError>()),
-      );
-    });
+    test(
+      'connect() with webStorageMode throws UnsupportedError on native',
+      () async {
+        if (_isWeb) return;
+        await expectLater(
+          KnexSQLite.connect(filename: ':memory:', webStorageMode: 'indexedDb'),
+          throwsA(isA<UnsupportedError>()),
+        );
+      },
+    );
 
-    test('fromConfig() with storageMode throws UnsupportedError on native',
-        () {
+    test('fromConfig() with storageMode throws UnsupportedError on native', () {
+      if (_isWeb) return;
       expect(
         () => SQLiteClient.fromConfig(
           KnexConfig(
             client: 'sqlite3',
-            connection: {
-              'filename': ':memory:',
-              'storageMode': 'indexedDb',
-            },
+            connection: {'filename': ':memory:', 'storageMode': 'indexedDb'},
           ),
         ),
         throwsA(isA<UnsupportedError>()),
       );
     });
 
-    test('invalid webStorageMode still throws ArgumentError on native', () async {
-      await expectLater(
-        KnexSQLite.connect(
-          filename: ':memory:',
-          webStorageMode: 'bogus',
-        ),
-        throwsA(isA<ArgumentError>()),
-      );
-    });
+    test(
+      'invalid webStorageMode still throws ArgumentError on native',
+      () async {
+        await expectLater(
+          KnexSQLite.connect(filename: ':memory:', webStorageMode: 'bogus'),
+          throwsA(isA<ArgumentError>()),
+        );
+      },
+    );
   });
 }

--- a/drivers/knex_dart_sqlite/test/sqlite_trx_test.dart
+++ b/drivers/knex_dart_sqlite/test/sqlite_trx_test.dart
@@ -162,5 +162,58 @@ void main() {
         throwsA(isA<StateError>()),
       );
     });
+
+    // ── 10. Concurrent top-level transactions are serialized ──────────────────
+
+    test('concurrent top-level trx calls are serialized — no interleaving',
+        () async {
+      // Fire two trx() calls without awaiting the first.
+      // If serialization is broken, the second BEGIN would race with the first,
+      // producing a "cannot start a transaction within a transaction" error.
+      final f1 = db.trx((tx) async {
+        await tx.insert(tx(_table).insert({'id': 40, 'name': 'Concurrent1'}));
+      });
+      final f2 = db.trx((tx) async {
+        await tx.insert(tx(_table).insert({'id': 41, 'name': 'Concurrent2'}));
+      });
+
+      await Future.wait([f1, f2]);
+
+      final rows = await db.select(db(_table).select(['*']));
+      expect(rows, hasLength(2));
+      final names = rows.map((r) => r['name']).toSet();
+      expect(names, containsAll(['Concurrent1', 'Concurrent2']));
+    });
+
+    // ── 11. Failed trx does not block the queue ───────────────────────────────
+
+    test('failed trx does not block subsequent transactions', () async {
+      // First trx rolls back.
+      await expectLater(
+        db.trx((_) async => throw Exception('fail')),
+        throwsA(isA<Exception>()),
+      );
+
+      // Second trx should still work.
+      await db.trx((tx) async {
+        await tx.insert(tx(_table).insert({'id': 50, 'name': 'AfterFail'}));
+      });
+
+      final rows = await db.select(db(_table).select(['*']));
+      expect(rows, hasLength(1));
+      expect(rows.first['name'], 'AfterFail');
+    });
+
+    // ── 12. webStorageMode param is silently ignored on native ────────────────
+
+    test('connect() with webStorageMode does not throw on native', () async {
+      final db2 = await KnexSQLite.connect(
+        filename: ':memory:',
+        webStorageMode: 'indexedDb',
+      );
+      addTearDown(db2.close);
+      // Should be usable normally.
+      await expectLater(db2.rawSql('SELECT 1'), completes);
+    });
   });
 }

--- a/drivers/knex_dart_sqlite/test/sqlite_trx_test.dart
+++ b/drivers/knex_dart_sqlite/test/sqlite_trx_test.dart
@@ -1,6 +1,7 @@
 /// Exhaustive transaction / error-path tests for KnexSQLite (in-memory, no Docker).
 library;
 
+import 'package:knex_dart/knex_dart.dart';
 import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
 import 'package:test/test.dart';
 
@@ -204,16 +205,43 @@ void main() {
       expect(rows.first['name'], 'AfterFail');
     });
 
-    // ── 12. webStorageMode param is silently ignored on native ────────────────
+    // ── 12. webStorageMode must fail fast on native ───────────────────────────
 
-    test('connect() with webStorageMode does not throw on native', () async {
-      final db2 = await KnexSQLite.connect(
-        filename: ':memory:',
-        webStorageMode: 'indexedDb',
+    test('connect() with webStorageMode throws UnsupportedError on native',
+        () async {
+      await expectLater(
+        KnexSQLite.connect(
+          filename: ':memory:',
+          webStorageMode: 'indexedDb',
+        ),
+        throwsA(isA<UnsupportedError>()),
       );
-      addTearDown(db2.close);
-      // Should be usable normally.
-      await expectLater(db2.rawSql('SELECT 1'), completes);
+    });
+
+    test('fromConfig() with storageMode throws UnsupportedError on native',
+        () {
+      expect(
+        () => SQLiteClient.fromConfig(
+          KnexConfig(
+            client: 'sqlite3',
+            connection: {
+              'filename': ':memory:',
+              'storageMode': 'indexedDb',
+            },
+          ),
+        ),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+
+    test('invalid webStorageMode still throws ArgumentError on native', () async {
+      await expectLater(
+        KnexSQLite.connect(
+          filename: ':memory:',
+          webStorageMode: 'bogus',
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
     });
   });
 }

--- a/drivers/knex_dart_sqlite/test/sqlite_watch_test.dart
+++ b/drivers/knex_dart_sqlite/test/sqlite_watch_test.dart
@@ -1,0 +1,335 @@
+import 'dart:async';
+
+import 'package:knex_dart/knex_dart.dart';
+import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
+import 'package:test/test.dart';
+
+/// Waits until [events] contains at least [n] items, or times out.
+Future<void> waitFor(List<Object?> events, int n) =>
+    Future.doWhile(() async {
+      if (events.length >= n) return false;
+      await Future.delayed(Duration(milliseconds: 5));
+      return true;
+    }).timeout(Duration(seconds: 2));
+
+void main() {
+  group('KnexSQLite watch()', () {
+    late KnexSQLite db;
+
+    setUp(() async {
+      db = await KnexSQLite.connect(filename: ':memory:');
+      await db.executeSchema((s) {
+        s.createTable('items', (t) {
+          t.increments('id');
+          t.string('name').notNullable();
+        });
+        s.createTable('tags', (t) {
+          t.increments('id');
+          t.string('label').notNullable();
+        });
+      });
+    });
+
+    tearDown(() => db.close());
+
+    test('implements WatchableClient', () {
+      expect(db, isA<WatchableClient>());
+    });
+
+    test('emits initial result immediately on subscribe', () async {
+      await db.insert(db('items').insert({'name': 'alpha'}));
+
+      final first = await db.watch(db('items')).first;
+      expect(first, hasLength(1));
+      expect(first.first['name'], 'alpha');
+    });
+
+    test('re-emits after insert', () async {
+      final events = <List<Map<String, dynamic>>>[];
+      final sub = db.watch(db('items')).listen(events.add);
+
+      await waitFor(events, 1); // wait for initial emit
+      await db.insert(db('items').insert({'name': 'beta'}));
+      await waitFor(events, 2);
+
+      expect(events.last, hasLength(1));
+      expect(events.last.first['name'], 'beta');
+      await sub.cancel();
+    });
+
+    test('re-emits after update', () async {
+      await db.insert(db('items').insert({'name': 'old'}));
+
+      final events = <List<Map<String, dynamic>>>[];
+      final sub = db.watch(db('items')).listen(events.add);
+
+      await waitFor(events, 1);
+      await db.update(
+        db('items').where('name', 'old').update({'name': 'new'}),
+      );
+      await waitFor(events, 2);
+
+      expect(events.last.first['name'], 'new');
+      await sub.cancel();
+    });
+
+    test('re-emits after delete', () async {
+      await db.insert(db('items').insert({'name': 'gone'}));
+
+      final events = <List<Map<String, dynamic>>>[];
+      final sub = db.watch(db('items')).listen(events.add);
+
+      await waitFor(events, 1);
+      await db.delete(db('items').where('name', 'gone').delete());
+      await waitFor(events, 2);
+
+      expect(events.last, isEmpty);
+      await sub.cancel();
+    });
+
+    test('does not re-emit for unrelated table writes', () async {
+      final events = <List<Map<String, dynamic>>>[];
+      final sub = db.watch(db('items')).listen(events.add);
+
+      await waitFor(events, 1); // initial emit landed
+      final countAfterInit = events.length;
+
+      await db.insert(db('tags').insert({'label': 'unrelated'}));
+      await Future.delayed(Duration(milliseconds: 30));
+
+      expect(events.length, countAfterInit); // no new emit
+      await sub.cancel();
+    });
+
+    test('cancelling the subscription stops re-emits', () async {
+      final events = <List<Map<String, dynamic>>>[];
+      final sub = db.watch(db('items')).listen(events.add);
+
+      await waitFor(events, 1);
+      await sub.cancel();
+      final countAfterCancel = events.length;
+
+      await db.insert(db('items').insert({'name': 'after-cancel'}));
+      await Future.delayed(Duration(milliseconds: 30));
+
+      expect(events.length, countAfterCancel);
+    });
+
+    test('re-emits when a joined table changes', () async {
+      await db.executeSchema((s) {
+        s.createTable('orders', (t) {
+          t.increments('id');
+          t.integer('item_id').notNullable();
+          t.integer('qty').notNullable();
+        });
+      });
+
+      await db.insert(db('items').insert({'name': 'widget'}));
+      final itemId = (await db.select(db('items')))[0]['id'] as int;
+
+      final joinQuery = db('items').join(
+        'orders',
+        (j) => j.on('items.id', 'orders.item_id'),
+      );
+
+      final events = <List<Map<String, dynamic>>>[];
+      final sub = db.watch(joinQuery).listen(events.add);
+
+      await waitFor(events, 1); // initial emit (empty — no orders yet)
+
+      // Write to the joined table — should trigger re-emit.
+      await db.insert(
+        db('orders').insert({'item_id': itemId, 'qty': 5}),
+      );
+      await waitFor(events, 2);
+
+      expect(events.last, hasLength(1));
+      expect(events.last.first['qty'], 5);
+      await sub.cancel();
+    });
+
+    test('throws StateError when called on a closed database', () async {
+      await db.close();
+      expect(
+        () => db.watch(db('items')),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('multiple concurrent watch() streams on the same table are independent',
+        () async {
+      final eventsA = <List<Map<String, dynamic>>>[];
+      final eventsB = <List<Map<String, dynamic>>>[];
+
+      final subA = db.watch(db('items')).listen(eventsA.add);
+      final subB = db.watch(db('items')).listen(eventsB.add);
+
+      await waitFor(eventsA, 1);
+      await waitFor(eventsB, 1);
+
+      await db.insert(db('items').insert({'name': 'shared'}));
+      await waitFor(eventsA, 2);
+      await waitFor(eventsB, 2);
+
+      expect(eventsA.last, hasLength(1));
+      expect(eventsB.last, hasLength(1));
+      await subA.cancel();
+      await subB.cancel();
+    });
+
+    test('rawSql write triggers re-emit', () async {
+      final events = <List<Map<String, dynamic>>>[];
+      final sub = db.watch(db('items')).listen(events.add);
+
+      await waitFor(events, 1);
+      await db.rawSql("INSERT INTO \"items\" (\"name\") VALUES (?)", ['raw']);
+      await waitFor(events, 2);
+
+      expect(events.last.first['name'], 'raw');
+      await sub.cancel();
+    });
+
+    test('DDL via executeSchema does not trigger re-emit', () async {
+      final events = <List<Map<String, dynamic>>>[];
+      final sub = db.watch(db('items')).listen(events.add);
+
+      await waitFor(events, 1);
+      final countAfterInit = events.length;
+
+      await db.executeSchema((s) {
+        s.createTable('unrelated_ddl', (t) => t.increments('id'));
+      });
+      await Future.delayed(Duration(milliseconds: 30));
+
+      expect(events.length, countAfterInit);
+      await sub.cancel();
+    });
+
+    test('select() error inside emit propagates as stream error', () async {
+      final errors = <Object>[];
+      // Watch a table that doesn't exist — initial emit should error.
+      final sub = db
+          .watch(db('nonexistent_table'))
+          .listen((_) {}, onError: errors.add);
+
+      await Future.delayed(Duration(milliseconds: 50));
+      expect(errors, isNotEmpty);
+      await sub.cancel();
+    });
+
+    test('second listen() on same watch stream throws StateError', () async {
+      final stream = db.watch(db('items'));
+      final sub = stream.listen((_) {});
+      expect(() => stream.listen((_) {}), throwsStateError);
+      await sub.cancel();
+    });
+
+    group('transaction safety', () {
+      test('committed transaction triggers re-emit', () async {
+        final events = <List<Map<String, dynamic>>>[];
+        final sub = db.watch(db('items')).listen(events.add);
+
+        await waitFor(events, 1);
+        await db.trx((trx) async {
+          await trx.insert(db('items').insert({'name': 'committed'}));
+        });
+        await waitFor(events, 2);
+
+        expect(events.last.first['name'], 'committed');
+        await sub.cancel();
+      });
+
+      test('rolled-back transaction does not trigger re-emit', () async {
+        final events = <List<Map<String, dynamic>>>[];
+        final sub = db.watch(db('items')).listen(events.add);
+
+        await waitFor(events, 1);
+        final countAfterInit = events.length;
+
+        try {
+          await db.trx((trx) async {
+            await trx.insert(db('items').insert({'name': 'phantom'}));
+            throw Exception('rollback');
+          });
+        } catch (_) {}
+        await Future.delayed(Duration(milliseconds: 30));
+
+        expect(events.length, countAfterInit); // no re-emit for rolled-back write
+        final rows = await db.select(db('items'));
+        expect(rows.any((r) => r['name'] == 'phantom'), isFalse);
+        await sub.cancel();
+      });
+
+      test('savepoint rollback does not pollute outer commit re-emit', () async {
+        final events = <List<Map<String, dynamic>>>[];
+        final sub = db.watch(db('items')).listen(events.add);
+
+        await waitFor(events, 1);
+
+        await db.trx((outer) async {
+          await outer.insert(db('items').insert({'name': 'outer'}));
+          // Inner savepoint rolls back — its write should not appear.
+          try {
+            await outer.trx((inner) async {
+              await inner.insert(db('items').insert({'name': 'inner-phantom'}));
+              throw Exception('savepoint rollback');
+            });
+          } catch (_) {}
+        });
+        await waitFor(events, 2);
+
+        final names = events.last.map((r) => r['name']).toList();
+        expect(names, contains('outer'));
+        expect(names, isNot(contains('inner-phantom')));
+        await sub.cancel();
+      });
+    });
+
+    group('debounce / maxPendingWrites', () {
+      test('debounce collapses rapid writes into one re-emit', () async {
+        final events = <List<Map<String, dynamic>>>[];
+        final sub = db
+            .watch(db('items'), debounce: Duration(milliseconds: 80))
+            .listen(events.add);
+
+        await waitFor(events, 1); // wait for initial emit
+        final countAfterInit = events.length;
+
+        // Five sequential inserts — all complete well within the 80ms window.
+        for (var i = 0; i < 5; i++) {
+          await db.insert(db('items').insert({'name': 'item$i'}));
+        }
+        // Wait for debounce window + query round-trip.
+        await Future.delayed(Duration(milliseconds: 200));
+
+        expect(events.length, countAfterInit + 1);
+        expect(events.last, hasLength(5));
+        await sub.cancel();
+      });
+
+      test('maxPendingWrites triggers re-emit before debounce window', () async {
+        final events = <List<Map<String, dynamic>>>[];
+        final sub = db
+            .watch(
+              db('items'),
+              debounce: Duration(seconds: 10), // very long window
+              maxPendingWrites: 3,
+            )
+            .listen(events.add);
+
+        await waitFor(events, 1); // wait for initial emit
+        final countAfterInit = events.length;
+
+        // Insert 3 rows — should hit the count ceiling before the 10s timer.
+        for (var i = 0; i < 3; i++) {
+          await db.insert(db('items').insert({'name': 'item$i'}));
+        }
+        await waitFor(events, countAfterInit + 1);
+
+        expect(events.length, countAfterInit + 1);
+        expect(events.last, hasLength(3));
+        await sub.cancel();
+      });
+    });
+  });
+}

--- a/drivers/knex_dart_turso/pubspec.yaml
+++ b/drivers/knex_dart_turso/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  knex_dart: ^1.2.1
+  knex_dart: ^1.3.0
   http: ^1.2.0
   universal_io: ^2.3.1
 

--- a/integrations/knex_dart_otel/pubspec.yaml
+++ b/integrations/knex_dart_otel/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  knex_dart: ^1.2.1
+  knex_dart: ^1.3.0
   dartastic_opentelemetry_api: ^0.9.0
 
 dev_dependencies:

--- a/packages/knex_dart/CHANGELOG.md
+++ b/packages/knex_dart/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 1.3.0
+
+- Added the public `WatchableClient` contract for drivers that support
+  reactive query streams.
+- Exported the doc snippet runtime helpers used by the docs site and playground
+  through the public `knex_dart` API.
+- Added executable doc snippet runtime support and regression coverage for
+  snippet wrapping and dialect validation.
+- Documentation updates for runnable snippets and SQLite reactive examples.
+
 ## 1.2.1
 
 - Improved query compilation hot paths by replacing timestamp/random UID

--- a/packages/knex_dart/README.md
+++ b/packages/knex_dart/README.md
@@ -37,7 +37,7 @@ Try queries in the browser playground: **https://playground.knex.mahawarkartikey
 - [Joins](https://docs.knex.mahawarkartikey.in/query-building/joins) — INNER, LEFT, RIGHT, FULL OUTER, LATERAL
 - [Window Functions](https://docs.knex.mahawarkartikey.in/query-building/window-functions) — RANK, LEAD, LAG, frame clauses
 - [Transactions](https://docs.knex.mahawarkartikey.in/query-building/transactions) — atomic operations + nested savepoints
-- [Streaming](https://docs.knex.mahawarkartikey.in/connections/streaming) — memory-efficient large result sets
+- [Streaming](https://docs.knex.mahawarkartikey.in/connections/streaming) — row streams and SQLite reactive watch queries
 - [Migrations](https://docs.knex.mahawarkartikey.in/migration/migrations) — code-first and SQL-directory sources
 - [Dialect Lint](https://docs.knex.mahawarkartikey.in/tooling/dialect-lint) — optional static analysis plugin
 - [OpenTelemetry](https://docs.knex.mahawarkartikey.in/tooling/opentelemetry) — query spans and DB client duration metrics
@@ -85,6 +85,7 @@ await db.destroy();
 
 ### SQLite
 
+<!-- doc:run scope=local expect_stdout='Alice' -->
 ```dart
 import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
 
@@ -100,7 +101,49 @@ await db.executeSchema(
 );
 
 await db.insert(db('users').insert({'name': 'Alice'}));
-await db.destroy();
+final rows = await db.select(db('users').select(['name']));
+print(rows.first['name']);
+await db.close();
+```
+
+SQLite also supports reactive query watching:
+
+<!-- doc:run scope=local expect_stdout='users changed: 1' -->
+```dart
+import 'dart:async';
+
+import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
+
+final db = await KnexSQLite.connect(filename: ':memory:');
+await db.executeSchema((schema) {
+  schema.createTable('users', (t) {
+    t.increments('id');
+    t.string('name');
+    t.boolean('active');
+  });
+});
+
+final initial = Completer<void>();
+final updated = Completer<List<Map<String, dynamic>>>();
+var sawInitial = false;
+
+final sub = db.watch(
+  db('users').where('active', '=', true),
+).listen((rows) {
+  if (!sawInitial) {
+    sawInitial = true;
+    if (!initial.isCompleted) initial.complete();
+    return;
+  }
+  if (!updated.isCompleted) updated.complete(rows);
+});
+
+await initial.future;
+await db.insert(db('users').insert({'name': 'Alice', 'active': true}));
+final rows = await updated.future;
+print('users changed: ${rows.length}');
+await sub.cancel();
+await db.close();
 ```
 
 ### DuckDB (OLAP / Browser WASM)
@@ -126,6 +169,7 @@ DuckDB runs natively on macOS/Linux/Windows and in the **browser via WASM** — 
 
 Generate dialect-correct SQL without any driver installed:
 
+<!-- doc:run scope=local expect_stdout_contains='select * from "users" where "active" = $1' -->
 ```dart
 import 'package:knex_dart/knex_dart.dart';
 import 'package:knex_dart_capabilities/knex_dart_capabilities.dart';

--- a/packages/knex_dart/README.md
+++ b/packages/knex_dart/README.md
@@ -50,7 +50,7 @@ Add the driver for your database — it pulls in `knex_dart` automatically:
 dependencies:
   knex_dart_postgres: ^0.3.1   # PostgreSQL
   # knex_dart_mysql: ^0.3.1    # MySQL
-  # knex_dart_sqlite: ^0.3.0   # SQLite
+  # knex_dart_sqlite: ^0.4.0   # SQLite
   # knex_dart_duckdb: ^0.2.1   # DuckDB (OLAP / browser WASM)
 ```
 
@@ -58,7 +58,7 @@ For SQL generation only (no live connection):
 
 ```yaml
 dependencies:
-  knex_dart: ^1.2.1
+  knex_dart: ^1.3.0
   knex_dart_capabilities: ^0.3.0
 ```
 

--- a/packages/knex_dart/lib/knex_dart.dart
+++ b/packages/knex_dart/lib/knex_dart.dart
@@ -65,3 +65,4 @@ export 'src/transaction/transaction.dart';
 export 'src/util/knex_exception.dart';
 export 'src/util/enums.dart';
 export 'src/util/types.dart';
+export 'src/util/doc_snippet_runtime.dart';

--- a/packages/knex_dart/lib/knex_dart.dart
+++ b/packages/knex_dart/lib/knex_dart.dart
@@ -31,6 +31,7 @@ export 'src/knex_query.dart';
 export 'src/client/client.dart';
 export 'src/client/knex_config.dart';
 export 'src/client/query_interceptor.dart';
+export 'src/client/watchable_client.dart';
 
 // Raw and Ref
 export 'src/raw.dart';

--- a/packages/knex_dart/lib/src/client/watchable_client.dart
+++ b/packages/knex_dart/lib/src/client/watchable_client.dart
@@ -1,0 +1,38 @@
+import '../query/query_builder.dart';
+
+/// Mixin for driver wrappers that support reactive query watching.
+///
+/// Drivers that can observe table mutations implement this mixin.
+/// Callers can check `db is WatchableClient` before calling [watch].
+abstract mixin class WatchableClient {
+  /// Watches a query and re-emits results whenever any of its source tables change.
+  ///
+  /// The stream emits immediately on subscription with the current result set,
+  /// then re-emits after each relevant write.
+  ///
+  /// [debounce] sets the silence window — a re-query fires after this duration
+  /// elapses with no further writes. Defaults to null (no time-based debounce).
+  ///
+  /// [maxPendingWrites] sets a write-count ceiling — a re-query fires as soon
+  /// as this many writes accumulate, even if [debounce] has not elapsed.
+  /// Defaults to null (no count ceiling).
+  ///
+  /// When both are set, whichever ceiling is hit first triggers the re-query.
+  ///
+  /// **Single-listener only.** The returned stream is not a broadcast stream;
+  /// calling `.listen()` a second time throws a [StateError]. If multiple
+  /// consumers need the same stream, wrap with `.asBroadcastStream()`.
+  ///
+  /// **Subquery tables are not tracked.** When the primary table is a subquery
+  /// rather than a plain string (e.g. `db(db('items').as('sub'))`), no tables
+  /// can be inferred and the stream will emit once on subscribe but never
+  /// re-emit on writes.
+  ///
+  /// **DDL does not trigger re-emits.** SQLite's UPDATE_HOOK does not fire for
+  /// `CREATE TABLE`, `ALTER TABLE`, or other schema changes.
+  Stream<List<Map<String, dynamic>>> watch(
+    QueryBuilder query, {
+    Duration? debounce,
+    int? maxPendingWrites,
+  });
+}

--- a/packages/knex_dart/lib/src/util/doc_snippet_runtime.dart
+++ b/packages/knex_dart/lib/src/util/doc_snippet_runtime.dart
@@ -69,7 +69,8 @@ _SplitSnippet _splitSnippet(String code) {
       topLevel.add(line);
       braceDepth += '{'.allMatches(line).length;
       braceDepth -= '}'.allMatches(line).length;
-      if (braceDepth <= 0 && trimmed.endsWith('}')) {
+      final endsDeclaration = trimmed.endsWith('}') || trimmed.endsWith(';');
+      if (braceDepth <= 0 && endsDeclaration) {
         inTopLevelBlock = false;
       }
     } else {
@@ -132,10 +133,11 @@ String _buildPlaygroundProgram(_SplitSnippet parts, String dialect) {
   }
 
   if (!parts.hasTopLevelMain) {
-    final needsDbPreamble = !(parts.body.join('\n').contains(
-          'final db = KnexQuery.forDialect',
-        ) ||
-        parts.topLevel.join('\n').contains('final db = KnexQuery.forDialect'));
+    final needsDbPreamble =
+        !(parts.body.join('\n').contains('final db = KnexQuery.forDialect') ||
+            parts.topLevel
+                .join('\n')
+                .contains('final db = KnexQuery.forDialect'));
     buf.writeln('void main() {');
     if (needsDbPreamble) {
       buf.writeln(
@@ -153,7 +155,12 @@ String _buildPlaygroundProgram(_SplitSnippet parts, String dialect) {
 }
 
 String _dialectEnum(String dialect) => switch (dialect) {
+  'postgres' => 'KnexDialect.postgres',
   'sqlite' => 'KnexDialect.sqlite',
   'mysql' => 'KnexDialect.mysql',
-  _ => 'KnexDialect.postgres',
+  _ => throw ArgumentError.value(
+    dialect,
+    'dialect',
+    'Unsupported dialect for doc snippet runtime',
+  ),
 };

--- a/packages/knex_dart/lib/src/util/doc_snippet_runtime.dart
+++ b/packages/knex_dart/lib/src/util/doc_snippet_runtime.dart
@@ -1,0 +1,159 @@
+enum DocSnippetTarget { local, playground }
+
+class _SplitSnippet {
+  final List<String> imports;
+  final List<String> topLevel;
+  final List<String> body;
+  final bool hasTopLevelMain;
+
+  const _SplitSnippet({
+    required this.imports,
+    required this.topLevel,
+    required this.body,
+    required this.hasTopLevelMain,
+  });
+}
+
+const _playgroundHelperTopLevel =
+    "void sql(SqlString s) =>\n"
+    "    print(jsonEncode({'sql': s.sql, 'bindings': s.bindings}));\n"
+    "\n"
+    "void schema(List<Map<String, dynamic>> stmts) {\n"
+    "  for (final s in stmts) {\n"
+    "    print(jsonEncode({\n"
+    "      'sql': s['sql'] as String,\n"
+    "      'bindings': (s['bindings'] as List?)?.cast<dynamic>() ?? [],\n"
+    "    }));\n"
+    "  }\n"
+    "}\n";
+
+String buildDocSnippetProgram(
+  String code, {
+  required DocSnippetTarget target,
+  String dialect = 'postgres',
+}) {
+  final parts = _splitSnippet(code);
+  return switch (target) {
+    DocSnippetTarget.local => _buildLocalProgram(parts),
+    DocSnippetTarget.playground => _buildPlaygroundProgram(parts, dialect),
+  };
+}
+
+_SplitSnippet _splitSnippet(String code) {
+  final codeLines = code.split('\n');
+  final imports = <String>[];
+  final topLevel = <String>[];
+  final body = <String>[];
+
+  var inTopLevelBlock = false;
+  var braceDepth = 0;
+
+  for (final line in codeLines) {
+    final trimmed = line.trim();
+
+    if (trimmed.startsWith('import ') || trimmed.startsWith('export ')) {
+      imports.add(line);
+      continue;
+    }
+
+    final isTopLevelDecl = RegExp(
+      r'^(void |Future|Stream|class |typedef |enum |extension |abstract )',
+    ).hasMatch(trimmed);
+
+    if (isTopLevelDecl && !inTopLevelBlock) {
+      inTopLevelBlock = true;
+      braceDepth = 0;
+    }
+
+    if (inTopLevelBlock) {
+      topLevel.add(line);
+      braceDepth += '{'.allMatches(line).length;
+      braceDepth -= '}'.allMatches(line).length;
+      if (braceDepth <= 0 && trimmed.endsWith('}')) {
+        inTopLevelBlock = false;
+      }
+    } else {
+      body.add(line);
+    }
+  }
+
+  return _SplitSnippet(
+    imports: imports,
+    topLevel: topLevel,
+    body: body,
+    hasTopLevelMain: RegExp(r'\bmain\s*\(').hasMatch(topLevel.join('\n')),
+  );
+}
+
+String _buildLocalProgram(_SplitSnippet parts) {
+  final buf = StringBuffer();
+  buf.writeln(
+    '// ignore_for_file: unused_local_variable, unused_import, dead_code,',
+  );
+  buf.writeln(
+    '// ignore_for_file: unawaited_futures, avoid_print, unused_element',
+  );
+  for (final imp in parts.imports) {
+    buf.writeln(imp);
+  }
+  buf.writeln();
+  for (final tl in parts.topLevel) {
+    buf.writeln(tl);
+  }
+  if (parts.body.isNotEmpty && !parts.hasTopLevelMain) {
+    buf.writeln('Future<void> main() async {');
+    for (final b in parts.body) {
+      buf.writeln('  $b');
+    }
+    buf.writeln('}');
+  } else if (!parts.hasTopLevelMain) {
+    buf.writeln('Future<void> main() async {}');
+  }
+
+  return buf.toString();
+}
+
+String _buildPlaygroundProgram(_SplitSnippet parts, String dialect) {
+  final allImports = <String>{
+    "import 'dart:convert';",
+    "import 'package:knex_dart/knex_dart.dart';",
+    "import 'package:knex_dart_capabilities/knex_dart_capabilities.dart';",
+    ...parts.imports,
+  };
+
+  final buf = StringBuffer();
+  for (final imp in allImports) {
+    buf.writeln(imp);
+  }
+  buf.writeln();
+  buf.writeln(_playgroundHelperTopLevel);
+  for (final tl in parts.topLevel) {
+    buf.writeln(tl);
+  }
+
+  if (!parts.hasTopLevelMain) {
+    final needsDbPreamble = !(parts.body.join('\n').contains(
+          'final db = KnexQuery.forDialect',
+        ) ||
+        parts.topLevel.join('\n').contains('final db = KnexQuery.forDialect'));
+    buf.writeln('void main() {');
+    if (needsDbPreamble) {
+      buf.writeln(
+        '  final db = KnexQuery.forDialect(${_dialectEnum(dialect)});',
+      );
+      buf.writeln();
+    }
+    for (final b in parts.body) {
+      buf.writeln('  $b');
+    }
+    buf.writeln('}');
+  }
+
+  return buf.toString();
+}
+
+String _dialectEnum(String dialect) => switch (dialect) {
+  'sqlite' => 'KnexDialect.sqlite',
+  'mysql' => 'KnexDialect.mysql',
+  _ => 'KnexDialect.postgres',
+};

--- a/packages/knex_dart/pubspec.yaml
+++ b/packages/knex_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: knex_dart
 description: A Dart SQL query builder inspired by Knex.js. Use driver packages (knex_dart_postgres, knex_dart_mysql, knex_dart_sqlite) to connect to databases.
-version: 1.2.1
+version: 1.3.0
 repository: https://github.com/kartikey321/knex-dart
 homepage: https://github.com/kartikey321/knex-dart
 issue_tracker: https://github.com/kartikey321/knex-dart/issues

--- a/packages/knex_dart/test/util/doc_snippet_runtime_test.dart
+++ b/packages/knex_dart/test/util/doc_snippet_runtime_test.dart
@@ -1,0 +1,76 @@
+import 'package:knex_dart/src/util/doc_snippet_runtime.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('buildDocSnippetProgram', () {
+    test('local wraps snippet body in async main', () {
+      final code = '''
+import 'package:knex_dart/knex_dart.dart';
+
+final q = KnexQuery.forClient('mysql2');
+print(q.from('users').toSQL().sql);
+''';
+
+      final program = buildDocSnippetProgram(
+        code,
+        target: DocSnippetTarget.local,
+      );
+
+      expect(program, contains("Future<void> main() async {"));
+      expect(program, contains("final q = KnexQuery.forClient('mysql2');"));
+    });
+
+    test('local does not double-wrap explicit main', () {
+      final code = '''
+void main() {
+  print('ok');
+}
+''';
+
+      final program = buildDocSnippetProgram(
+        code,
+        target: DocSnippetTarget.local,
+      );
+
+      expect(
+        RegExp(r'Future<void> main\(\) async \{').allMatches(program),
+        isEmpty,
+      );
+      expect(RegExp(r'void main\(\)').allMatches(program).length, 1);
+    });
+
+    test('playground injects helpers and db preamble', () {
+      final code = '''
+sql(db.from('users').toSQL());
+''';
+
+      final program = buildDocSnippetProgram(
+        code,
+        target: DocSnippetTarget.playground,
+        dialect: 'postgres',
+      );
+
+      expect(program, contains("import 'dart:convert';"));
+      expect(program, contains('void sql(SqlString s) =>'));
+      expect(
+        program,
+        contains('final db = KnexQuery.forDialect(KnexDialect.postgres);'),
+      );
+    });
+
+    test('playground preserves explicit main without adding another', () {
+      final code = '''
+void main() {
+  print('hello');
+}
+''';
+
+      final program = buildDocSnippetProgram(
+        code,
+        target: DocSnippetTarget.playground,
+      );
+
+      expect(RegExp(r'void main\(\)').allMatches(program).length, 1);
+    });
+  });
+}

--- a/packages/knex_dart/test/util/doc_snippet_runtime_test.dart
+++ b/packages/knex_dart/test/util/doc_snippet_runtime_test.dart
@@ -92,7 +92,12 @@ print(q.from('users').toSQL().sql);
           "typedef RowMapper = String Function(Map<String, dynamic> row);",
         ),
       );
-      expect(program, contains('Future<void> main() async {'));
+      final typedefIdx = program.indexOf(
+        "typedef RowMapper = String Function(Map<String, dynamic> row);",
+      );
+      final mainIdx = program.indexOf('Future<void> main() async {');
+      expect(typedefIdx, isNonNegative);
+      expect(mainIdx, greaterThan(typedefIdx));
       expect(program, contains("print(q.from('users').toSQL().sql);"));
     });
 

--- a/packages/knex_dart/test/util/doc_snippet_runtime_test.dart
+++ b/packages/knex_dart/test/util/doc_snippet_runtime_test.dart
@@ -72,5 +72,39 @@ void main() {
 
       expect(RegExp(r'void main\(\)').allMatches(program).length, 1);
     });
+
+    test('local keeps one-line top-level declarations out of main body', () {
+      final code = '''
+typedef RowMapper = String Function(Map<String, dynamic> row);
+
+final q = KnexQuery.forClient('mysql2');
+print(q.from('users').toSQL().sql);
+''';
+
+      final program = buildDocSnippetProgram(
+        code,
+        target: DocSnippetTarget.local,
+      );
+
+      expect(
+        program,
+        contains(
+          "typedef RowMapper = String Function(Map<String, dynamic> row);",
+        ),
+      );
+      expect(program, contains('Future<void> main() async {'));
+      expect(program, contains("print(q.from('users').toSQL().sql);"));
+    });
+
+    test('playground rejects unsupported dialects', () {
+      expect(
+        () => buildDocSnippetProgram(
+          'sql(db.from(\'users\').toSQL());',
+          target: DocSnippetTarget.playground,
+          dialect: 'mssql',
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
   });
 }

--- a/tool/check_doc_snippets.dart
+++ b/tool/check_doc_snippets.dart
@@ -266,8 +266,14 @@ DocRunDirective? _parseRunDirective(
   final expectStdout = expectStdoutRaw == null
       ? null
       : _unescapeDirectiveValue(expectStdoutRaw);
-  final expectStdoutContains = args['expect_stdout_contains'];
-  final expectStderrContains = args['expect_stderr_contains'];
+  final expectStdoutContainsRaw = args['expect_stdout_contains'];
+  final expectStdoutContains = expectStdoutContainsRaw == null
+      ? null
+      : _unescapeDirectiveValue(expectStdoutContainsRaw);
+  final expectStderrContainsRaw = args['expect_stderr_contains'];
+  final expectStderrContains = expectStderrContainsRaw == null
+      ? null
+      : _unescapeDirectiveValue(expectStderrContainsRaw);
   final expectExitRaw = args['expect_exit'];
   final expectExit = expectExitRaw == null ? 0 : int.parse(expectExitRaw);
 
@@ -776,7 +782,7 @@ analyzer:
     } else {
       // Insert before the closing -->
       updatedLine = originalLine.replaceFirst(
-        ' -->',
+        RegExp(r'\s*-->$'),
         ' expect_stdout="$escaped" -->',
       );
     }

--- a/tool/check_doc_snippets.dart
+++ b/tool/check_doc_snippets.dart
@@ -8,6 +8,8 @@
 
 import 'dart:io';
 
+import 'package:knex_dart/src/util/doc_snippet_runtime.dart';
+
 // ── Config ────────────────────────────────────────────────────────────────────
 
 final _docGlobs = [
@@ -140,32 +142,133 @@ class Snippet {
   final int startLine; // 1-based line of the first code line inside the fence
   final String code;
   final bool nocheck;
-  Snippet(this.file, this.startLine, this.code, {this.nocheck = false});
+  final DocRunDirective? runDirective;
+  Snippet(
+    this.file,
+    this.startLine,
+    this.code, {
+    this.nocheck = false,
+    this.runDirective,
+  });
+}
+
+class DocRunDirective {
+  final String scope;
+  final String? expectStdout;
+  final String? expectStdoutContains;
+  final String? expectStderrContains;
+  final int expectExit;
+
+  const DocRunDirective({
+    required this.scope,
+    this.expectStdout,
+    this.expectStdoutContains,
+    this.expectStderrContains,
+    this.expectExit = 0,
+  });
+}
+
+Map<String, String> _parseDirectiveArgs(String text) {
+  final args = <String, String>{};
+  final matches = RegExp(
+    r"""(\w+)=("([^"]*)"|'([^']*)'|(\S+))""",
+  ).allMatches(text);
+  for (final m in matches) {
+    args[m.group(1)!] = m.group(3) ?? m.group(4) ?? m.group(5) ?? '';
+  }
+  return args;
+}
+
+DocRunDirective? _parseRunDirective(String line) {
+  final trimmed = line.trim();
+  if (!trimmed.startsWith('<!--') || !trimmed.endsWith('-->')) return null;
+  if (!trimmed.contains('doc:run')) return null;
+
+  final args = _parseDirectiveArgs(trimmed);
+  final scope = args['scope'];
+  if (scope == null || scope.isEmpty) {
+    throw FormatException('doc:run directive is missing required scope=...');
+  }
+
+  final expectStdout = args['expect_stdout'];
+  final expectStdoutContains = args['expect_stdout_contains'];
+  final expectStderrContains = args['expect_stderr_contains'];
+  final expectExitRaw = args['expect_exit'];
+  final expectExit =
+      expectExitRaw == null ? 0 : int.parse(expectExitRaw);
+
+  if (expectStdout == null &&
+      expectStdoutContains == null &&
+      expectStderrContains == null &&
+      expectExitRaw == null) {
+    throw FormatException(
+      'doc:run directive must declare at least one expectation.',
+    );
+  }
+
+  return DocRunDirective(
+    scope: scope,
+    expectStdout: expectStdout,
+    expectStdoutContains: expectStdoutContains,
+    expectStderrContains: expectStderrContains,
+    expectExit: expectExit,
+  );
 }
 
 List<Snippet> _extractSnippets(String rootDir) {
   final results = <Snippet>[];
+  final errors = <String>[];
 
   void scanFile(String path) {
     final lines = File(path).readAsLinesSync();
     var inBlock = false;
     var blockStart = 0;
     final blockLines = <String>[];
+    String? pendingDirectiveLine;
+    int? pendingDirectiveLineNo;
 
     for (var i = 0; i < lines.length; i++) {
       final line = lines[i];
+      final trimmed = line.trim();
+      if (!inBlock && trimmed.startsWith('<!--') && trimmed.endsWith('-->')) {
+        pendingDirectiveLine = line;
+        pendingDirectiveLineNo = i + 1;
+        continue;
+      }
       if (!inBlock && line.trimLeft().startsWith('```dart')) {
         inBlock = true;
         blockStart = i + 2; // 1-based: first code line (fence is i+1)
         blockLines.clear();
       } else if (inBlock && line.trim() == '```') {
         inBlock = false;
-        // Check the line before the opening fence for <!-- doc:nocheck -->
-        final prevLine = i > 0 ? lines[i - blockLines.length - 2] : '';
-        final nocheck = prevLine.contains('doc:nocheck');
-        results.add(Snippet(path, blockStart, blockLines.join('\n'), nocheck: nocheck));
+        final directiveLine = pendingDirectiveLine;
+        final nocheck = directiveLine?.contains('doc:nocheck') ?? false;
+        DocRunDirective? runDirective;
+        if (directiveLine != null && directiveLine.contains('doc:run')) {
+          try {
+            runDirective = _parseRunDirective(directiveLine);
+          } on FormatException catch (e) {
+            errors.add(
+              '$path:${pendingDirectiveLineNo ?? blockStart}: ${e.message}',
+            );
+          }
+        }
+        results.add(
+          Snippet(
+            path,
+            blockStart,
+            blockLines.join('\n'),
+            nocheck: nocheck,
+            runDirective: runDirective,
+          ),
+        );
+        pendingDirectiveLine = null;
+        pendingDirectiveLineNo = null;
       } else if (inBlock) {
         blockLines.add(line);
+      } else {
+        pendingDirectiveLine = null;
+        pendingDirectiveLineNo = null;
       }
     }
   }
@@ -186,6 +289,10 @@ List<Snippet> _extractSnippets(String rootDir) {
   // Repo root README
   final rootReadme = File('$rootDir/README.md');
   if (rootReadme.existsSync()) scanFile(rootReadme.path);
+
+  if (errors.isNotEmpty) {
+    throw FormatException(errors.join('\n'));
+  }
 
   return results;
 }
@@ -209,75 +316,6 @@ List<String> _patternCheck(List<Snippet> snippets) {
 }
 
 // ── Layer 2: dart analyze on snippets with imports ───────────────────────────
-
-String _buildWrapper(String code) {
-  final codeLines = code.split('\n');
-  final imports = <String>[];
-  final topLevel = <String>[];
-  final body = <String>[];
-
-  // Simple classifier: import lines → imports; function/class defs → topLevel;
-  // everything else → body (goes inside main()).
-  var inTopLevelBlock = false;
-  var braceDepth = 0;
-
-  for (final line in codeLines) {
-    final trimmed = line.trim();
-
-    if (trimmed.startsWith('import ') || trimmed.startsWith('export ')) {
-      imports.add(line);
-      continue;
-    }
-
-    // Detect top-level declarations: void/Future/Stream functions, classes,
-    // typedefs, enums, extensions — keep them outside main().
-    final isTopLevelDecl = RegExp(
-      r'^(void |Future|Stream|class |typedef |enum |extension |abstract )',
-    ).hasMatch(trimmed);
-
-    if (isTopLevelDecl && !inTopLevelBlock) {
-      inTopLevelBlock = true;
-      braceDepth = 0;
-    }
-
-    if (inTopLevelBlock) {
-      topLevel.add(line);
-      braceDepth += '{'.allMatches(line).length;
-      braceDepth -= '}'.allMatches(line).length;
-      if (braceDepth <= 0 && trimmed.endsWith('}')) {
-        inTopLevelBlock = false;
-      }
-    } else {
-      body.add(line);
-    }
-  }
-
-  final buf = StringBuffer();
-  buf.writeln(
-    '// ignore_for_file: unused_local_variable, unused_import, dead_code,',
-  );
-  buf.writeln(
-    '// ignore_for_file: unawaited_futures, avoid_print, unused_element',
-  );
-  for (final imp in imports) {
-    buf.writeln(imp);
-  }
-  buf.writeln();
-  for (final tl in topLevel) {
-    buf.writeln(tl);
-  }
-  if (body.isNotEmpty) {
-    buf.writeln('Future<void> main() async {');
-    for (final b in body) {
-      buf.writeln('  $b');
-    }
-    buf.writeln('}');
-  } else {
-    buf.writeln('Future<void> main() async {}');
-  }
-
-  return buf.toString();
-}
 
 String _buildTempPubspec(String rootDir) {
   final buf = StringBuffer()
@@ -356,7 +394,9 @@ analyzer:
     final s = withImports[i];
     index[i] = s;
     // Embed source location so errors in the raw analyzer output are traceable.
-    final wrapped = '// SOURCE: ${s.file}:${s.startLine}\n${_buildWrapper(s.code)}';
+    final wrapped =
+        '// SOURCE: ${s.file}:${s.startLine}\n'
+        '${buildDocSnippetProgram(s.code, target: DocSnippetTarget.local)}';
     File('${libDir.path}/snippet_${i.toString().padLeft(4, '0')}.dart')
         .writeAsStringSync(wrapped);
   }
@@ -418,15 +458,158 @@ analyzer:
   return errors;
 }
 
+Future<List<String>> _runSnippets(
+  List<Snippet> snippets,
+  String rootDir, {
+  required String scope,
+}) async {
+  final runnable = snippets.where((s) {
+    final directive = s.runDirective;
+    if (directive == null) return false;
+    return directive.scope == scope;
+  }).toList();
+
+  if (runnable.isEmpty) return [];
+
+  final tmpDir = Directory.systemTemp.createTempSync('knex_dart_doc_run_');
+  final libDir = Directory('${tmpDir.path}/lib')..createSync();
+
+  File('${tmpDir.path}/pubspec.yaml')
+      .writeAsStringSync(_buildTempPubspec(rootDir));
+  File('${tmpDir.path}/analysis_options.yaml').writeAsStringSync('''
+analyzer:
+  errors:
+    unused_import: ignore
+    unused_local_variable: ignore
+    dead_code: ignore
+    unawaited_futures: ignore
+    unnecessary_import: ignore
+''');
+
+  final fileForSnippet = <Snippet, String>{};
+  for (var i = 0; i < runnable.length; i++) {
+    final s = runnable[i];
+    final fileName = 'snippet_${i.toString().padLeft(4, '0')}.dart';
+    fileForSnippet[s] = fileName;
+    final wrapped =
+        '// SOURCE: ${s.file}:${s.startLine}\n'
+        '${buildDocSnippetProgram(s.code, target: DocSnippetTarget.local)}';
+    File('${libDir.path}/$fileName').writeAsStringSync(wrapped);
+  }
+
+  final pubGet = await Process.run(
+    'dart',
+    ['pub', 'get'],
+    workingDirectory: tmpDir.path,
+  );
+  if (pubGet.exitCode != 0) {
+    tmpDir.deleteSync(recursive: true);
+    return [
+      'ERROR: dart pub get failed in temp runtime package:\n${pubGet.stderr}',
+    ];
+  }
+
+  final errors = <String>[];
+  for (final snippet in runnable) {
+    final directive = snippet.runDirective!;
+    final fileName = fileForSnippet[snippet]!;
+    final run = await Process.run(
+      'dart',
+      ['run', 'lib/$fileName'],
+      workingDirectory: tmpDir.path,
+    );
+    final stdoutText = (run.stdout as String).trimRight();
+    final stderrText = (run.stderr as String).trimRight();
+
+    if (run.exitCode != directive.expectExit) {
+      errors.add(
+        '${snippet.file}:${snippet.startLine}: expected exit code '
+        '${directive.expectExit}, got ${run.exitCode}.\n'
+        'stdout:\n$stdoutText\nstderr:\n$stderrText',
+      );
+      continue;
+    }
+
+    if (directive.expectStdout != null &&
+        stdoutText != directive.expectStdout) {
+      errors.add(
+        '${snippet.file}:${snippet.startLine}: stdout mismatch.\n'
+        'expected:\n${directive.expectStdout}\nactual:\n$stdoutText',
+      );
+    }
+
+    if (directive.expectStdoutContains != null &&
+        !stdoutText.contains(directive.expectStdoutContains!)) {
+      errors.add(
+        '${snippet.file}:${snippet.startLine}: stdout did not contain '
+        '"${directive.expectStdoutContains}".\nactual:\n$stdoutText',
+      );
+    }
+
+    if (directive.expectStderrContains != null &&
+        !stderrText.contains(directive.expectStderrContains!)) {
+      errors.add(
+        '${snippet.file}:${snippet.startLine}: stderr did not contain '
+        '"${directive.expectStderrContains}".\nactual:\n$stderrText',
+      );
+    }
+  }
+
+  tmpDir.deleteSync(recursive: true);
+  return errors;
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 Future<void> main(List<String> args) async {
-  final rootDir = args.isNotEmpty ? args[0] : Directory.current.path;
+  String rootDir = Directory.current.path;
+  String mode = 'check';
+  String? scope;
+
+  for (var i = 0; i < args.length; i++) {
+    final arg = args[i];
+    if (arg.startsWith('--mode=')) {
+      mode = arg.substring('--mode='.length);
+    } else if (arg == '--mode' && i + 1 < args.length) {
+      mode = args[++i];
+    } else if (arg.startsWith('--scope=')) {
+      scope = arg.substring('--scope='.length);
+    } else if (arg == '--scope' && i + 1 < args.length) {
+      scope = args[++i];
+    } else if (!arg.startsWith('--')) {
+      rootDir = arg;
+    }
+  }
 
   stdout.writeln('Scanning doc snippets in $rootDir…');
 
-  final snippets = _extractSnippets(rootDir);
+  late final List<Snippet> snippets;
+  try {
+    snippets = _extractSnippets(rootDir);
+  } on FormatException catch (e) {
+    stderr.writeln('\n✗ doc snippet directive issue(s) found:\n');
+    stderr.writeln(e.message);
+    exit(1);
+  }
   stdout.writeln('  Found ${snippets.length} dart snippets');
+
+  if (mode == 'run') {
+    if (scope == null || scope!.isEmpty) {
+      stderr.writeln('Missing required --scope for --mode=run');
+      exit(1);
+    }
+    stdout.writeln('  Running doc snippets for scope=$scope…');
+    final runErrors = await _runSnippets(snippets, rootDir, scope: scope!);
+    if (runErrors.isEmpty) {
+      stdout.writeln('✓ All runnable doc snippets OK for scope=$scope.');
+      exit(0);
+    }
+    stderr.writeln('\n✗ ${runErrors.length} runnable doc snippet issue(s) found:\n');
+    for (final e in runErrors) {
+      stderr.writeln('  $e');
+    }
+    exit(1);
+  }
 
   // Layer 0: README version drift
   final versionErrors = _versionDriftCheck(rootDir);

--- a/tool/check_doc_snippets.dart
+++ b/tool/check_doc_snippets.dart
@@ -6,6 +6,7 @@
 //   Layer 1 — forbidden-pattern scan (all snippets)
 //   Layer 2 — dart analyze on snippets that carry import statements
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:knex_dart/src/util/doc_snippet_runtime.dart';
@@ -15,10 +16,17 @@ import 'package:knex_dart/src/util/doc_snippet_runtime.dart';
 final _docGlobs = [
   'docs/site/content',
   'packages/knex_dart',
-  ...['knex_dart_postgres', 'knex_dart_mysql', 'knex_dart_sqlite',
-      'knex_dart_duckdb', 'knex_dart_mssql', 'knex_dart_turso',
-      'knex_dart_d1', 'knex_dart_bigquery', 'knex_dart_snowflake']
-      .map((d) => 'drivers/$d'),
+  ...[
+    'knex_dart_postgres',
+    'knex_dart_mysql',
+    'knex_dart_sqlite',
+    'knex_dart_duckdb',
+    'knex_dart_mssql',
+    'knex_dart_turso',
+    'knex_dart_d1',
+    'knex_dart_bigquery',
+    'knex_dart_snowflake',
+  ].map((d) => 'drivers/$d'),
   'integrations/knex_dart_otel',
 ];
 
@@ -36,7 +44,9 @@ final _forbidden = [
         'use trx.queryBuilder().client.raw()',
   ),
   (
-    RegExp(r'KnexQuery\.forDialect\([^)]+\)\s*\.(select|insert|update|delete|rawQuery|rawSql)\s*\('),
+    RegExp(
+      r'KnexQuery\.forDialect\([^)]+\)\s*\.(select|insert|update|delete|rawQuery|rawSql)\s*\(',
+    ),
     'KnexQuery.forDialect() returns a builder factory, not a live driver — '
         'cannot call select/insert/update/delete/rawQuery/rawSql on it directly',
   ),
@@ -108,9 +118,7 @@ List<String> _versionDriftCheck(String rootDir) {
   final errors = <String>[];
   // Pattern: optional leading spaces + optional # + spaces +
   //          package_name + : ^ + version
-  final lineRe = RegExp(
-    r'^\s*#?\s*(knex_dart\w*)\s*:\s*\^(\d+\.\d+\.\d+)',
-  );
+  final lineRe = RegExp(r'^\s*#?\s*(knex_dart\w*)\s*:\s*\^(\d+\.\d+\.\d+)');
 
   for (final path in _readmeFiles) {
     final file = File('$rootDir/$path');
@@ -158,6 +166,7 @@ class DocRunDirective {
   final String? expectStdoutContains;
   final String? expectStderrContains;
   final int expectExit;
+
   /// 1-based line number of the `<!-- doc:run ... -->` comment in the source file.
   final int directiveLineNo;
 
@@ -169,6 +178,54 @@ class DocRunDirective {
     this.expectStderrContains,
     this.expectExit = 0,
   });
+}
+
+class _ProcessResultWithTimeout {
+  final int exitCode;
+  final String stdout;
+  final String stderr;
+  final bool timedOut;
+
+  const _ProcessResultWithTimeout({
+    required this.exitCode,
+    required this.stdout,
+    required this.stderr,
+    required this.timedOut,
+  });
+}
+
+const _snippetRunTimeout = Duration(seconds: 45);
+
+Future<_ProcessResultWithTimeout> _runProcessWithTimeout(
+  String executable,
+  List<String> arguments, {
+  required String workingDirectory,
+  Duration timeout = _snippetRunTimeout,
+}) async {
+  final process = await Process.start(
+    executable,
+    arguments,
+    workingDirectory: workingDirectory,
+  );
+  final stdoutFuture = process.stdout.transform(systemEncoding.decoder).join();
+  final stderrFuture = process.stderr.transform(systemEncoding.decoder).join();
+  var timedOut = false;
+
+  late int exitCode;
+  try {
+    exitCode = await process.exitCode.timeout(timeout);
+  } on TimeoutException {
+    timedOut = true;
+    process.kill(ProcessSignal.sigkill);
+    exitCode = await process.exitCode;
+  }
+
+  return _ProcessResultWithTimeout(
+    exitCode: exitCode,
+    stdout: await stdoutFuture,
+    stderr: await stderrFuture,
+    timedOut: timedOut,
+  );
 }
 
 Map<String, String> _parseDirectiveArgs(String text) {
@@ -206,13 +263,13 @@ DocRunDirective? _parseRunDirective(
   }
 
   final expectStdoutRaw = args['expect_stdout'];
-  final expectStdout =
-      expectStdoutRaw == null ? null : _unescapeDirectiveValue(expectStdoutRaw);
+  final expectStdout = expectStdoutRaw == null
+      ? null
+      : _unescapeDirectiveValue(expectStdoutRaw);
   final expectStdoutContains = args['expect_stdout_contains'];
   final expectStderrContains = args['expect_stderr_contains'];
   final expectExitRaw = args['expect_exit'];
-  final expectExit =
-      expectExitRaw == null ? 0 : int.parse(expectExitRaw);
+  final expectExit = expectExitRaw == null ? 0 : int.parse(expectExitRaw);
 
   if (!allowBare &&
       expectStdout == null &&
@@ -235,7 +292,10 @@ DocRunDirective? _parseRunDirective(
   );
 }
 
-List<Snippet> _extractSnippets(String rootDir, {bool allowBareDirectives = false}) {
+List<Snippet> _extractSnippets(
+  String rootDir, {
+  bool allowBareDirectives = false,
+}) {
   final results = <Snippet>[];
   final errors = <String>[];
 
@@ -273,9 +333,7 @@ List<Snippet> _extractSnippets(String rootDir, {bool allowBareDirectives = false
               allowBare: allowBareDirectives,
             );
           } on FormatException catch (e) {
-            errors.add(
-              '$path:${directiveLineNo ?? blockStart}: ${e.message}',
-            );
+            errors.add('$path:${directiveLineNo ?? blockStart}: ${e.message}');
           }
         }
         results.add(
@@ -387,8 +445,9 @@ Future<List<String>> _analyzeSnippets(
   final tmpDir = Directory.systemTemp.createTempSync('knex_dart_doc_check_');
   final libDir = Directory('${tmpDir.path}/lib')..createSync();
 
-  File('${tmpDir.path}/pubspec.yaml')
-      .writeAsStringSync(_buildTempPubspec(rootDir));
+  File(
+    '${tmpDir.path}/pubspec.yaml',
+  ).writeAsStringSync(_buildTempPubspec(rootDir));
 
   // analysis_options: suppress wrapping-artifact errors, keep real API errors.
   // duplicate_definition: some doc snippets show two alternatives in one block.
@@ -422,16 +481,16 @@ analyzer:
     final wrapped =
         '// SOURCE: ${s.file}:${s.startLine}\n'
         '${buildDocSnippetProgram(s.code, target: DocSnippetTarget.local)}';
-    File('${libDir.path}/snippet_${i.toString().padLeft(4, '0')}.dart')
-        .writeAsStringSync(wrapped);
+    File(
+      '${libDir.path}/snippet_${i.toString().padLeft(4, '0')}.dart',
+    ).writeAsStringSync(wrapped);
   }
 
   // dart pub get
-  final pubGet = await Process.run(
-    'dart',
-    ['pub', 'get'],
-    workingDirectory: tmpDir.path,
-  );
+  final pubGet = await Process.run('dart', [
+    'pub',
+    'get',
+  ], workingDirectory: tmpDir.path);
   if (pubGet.exitCode != 0) {
     tmpDir.deleteSync(recursive: true);
     return [
@@ -440,11 +499,11 @@ analyzer:
   }
 
   // dart analyze
-  final analyze = await Process.run(
-    'dart',
-    ['analyze', '--fatal-warnings', 'lib/'],
-    workingDirectory: tmpDir.path,
-  );
+  final analyze = await Process.run('dart', [
+    'analyze',
+    '--fatal-warnings',
+    'lib/',
+  ], workingDirectory: tmpDir.path);
 
   final errors = <String>[];
 
@@ -499,8 +558,9 @@ Future<List<String>> _runSnippets(
   final tmpDir = Directory.systemTemp.createTempSync('knex_dart_doc_run_');
   final libDir = Directory('${tmpDir.path}/lib')..createSync();
 
-  File('${tmpDir.path}/pubspec.yaml')
-      .writeAsStringSync(_buildTempPubspec(rootDir));
+  File(
+    '${tmpDir.path}/pubspec.yaml',
+  ).writeAsStringSync(_buildTempPubspec(rootDir));
   File('${tmpDir.path}/analysis_options.yaml').writeAsStringSync('''
 analyzer:
   errors:
@@ -522,11 +582,10 @@ analyzer:
     File('${libDir.path}/$fileName').writeAsStringSync(wrapped);
   }
 
-  final pubGet = await Process.run(
-    'dart',
-    ['pub', 'get'],
-    workingDirectory: tmpDir.path,
-  );
+  final pubGet = await Process.run('dart', [
+    'pub',
+    'get',
+  ], workingDirectory: tmpDir.path);
   if (pubGet.exitCode != 0) {
     tmpDir.deleteSync(recursive: true);
     return [
@@ -538,13 +597,24 @@ analyzer:
   for (final snippet in runnable) {
     final directive = snippet.runDirective!;
     final fileName = fileForSnippet[snippet]!;
-    final run = await Process.run(
-      'dart',
-      ['run', 'lib/$fileName'],
-      workingDirectory: tmpDir.path,
+    stdout.writeln(
+      '  Running $scope snippet ${snippet.file}:${snippet.startLine}',
     );
-    final stdoutText = (run.stdout as String).trimRight();
-    final stderrText = (run.stderr as String).trimRight();
+    final run = await _runProcessWithTimeout('dart', [
+      'run',
+      'lib/$fileName',
+    ], workingDirectory: tmpDir.path);
+    final stdoutText = run.stdout.trimRight();
+    final stderrText = run.stderr.trimRight();
+
+    if (run.timedOut) {
+      errors.add(
+        '${snippet.file}:${snippet.startLine}: snippet timed out after '
+        '${_snippetRunTimeout.inSeconds}s.\n'
+        'stdout:\n$stdoutText\nstderr:\n$stderrText',
+      );
+      continue;
+    }
 
     if (run.exitCode != directive.expectExit) {
       errors.add(
@@ -609,8 +679,9 @@ Future<List<String>> _snapshotSnippets(
   final tmpDir = Directory.systemTemp.createTempSync('knex_dart_doc_snap_');
   final libDir = Directory('${tmpDir.path}/lib')..createSync();
 
-  File('${tmpDir.path}/pubspec.yaml')
-      .writeAsStringSync(_buildTempPubspec(rootDir));
+  File(
+    '${tmpDir.path}/pubspec.yaml',
+  ).writeAsStringSync(_buildTempPubspec(rootDir));
   File('${tmpDir.path}/analysis_options.yaml').writeAsStringSync('''
 analyzer:
   errors:
@@ -632,11 +703,10 @@ analyzer:
     File('${libDir.path}/$fileName').writeAsStringSync(wrapped);
   }
 
-  final pubGet = await Process.run(
-    'dart',
-    ['pub', 'get'],
-    workingDirectory: tmpDir.path,
-  );
+  final pubGet = await Process.run('dart', [
+    'pub',
+    'get',
+  ], workingDirectory: tmpDir.path);
   if (pubGet.exitCode != 0) {
     tmpDir.deleteSync(recursive: true);
     return [
@@ -657,11 +727,22 @@ analyzer:
   for (final snippet in runnable) {
     final directive = snippet.runDirective!;
     final fileName = fileForSnippet[snippet]!;
-    final run = await Process.run(
-      'dart',
-      ['run', 'lib/$fileName'],
-      workingDirectory: tmpDir.path,
+    stdout.writeln(
+      '  Snapshotting $scope snippet ${snippet.file}:${snippet.startLine}',
     );
+    final run = await _runProcessWithTimeout('dart', [
+      'run',
+      'lib/$fileName',
+    ], workingDirectory: tmpDir.path);
+
+    if (run.timedOut) {
+      errors.add(
+        '${snippet.file}:${snippet.startLine}: snippet timed out after '
+        '${_snippetRunTimeout.inSeconds}s — cannot snapshot.\n'
+        'stdout:\n${run.stdout}\nstderr:\n${run.stderr}',
+      );
+      continue;
+    }
 
     if (run.exitCode != 0) {
       errors.add(
@@ -671,7 +752,7 @@ analyzer:
       continue;
     }
 
-    final captured = (run.stdout as String).trimRight();
+    final captured = run.stdout.trimRight();
     final escaped = _escapeForDirective(captured);
 
     // Read the original directive line
@@ -694,11 +775,16 @@ analyzer:
       );
     } else {
       // Insert before the closing -->
-      updatedLine = originalLine.replaceFirst(' -->', ' expect_stdout="$escaped" -->');
+      updatedLine = originalLine.replaceFirst(
+        ' -->',
+        ' expect_stdout="$escaped" -->',
+      );
     }
 
-    mutations.putIfAbsent(snippet.file, () => <int, String>{})[directive.directiveLineNo] =
-        updatedLine;
+    mutations.putIfAbsent(
+      snippet.file,
+      () => <int, String>{},
+    )[directive.directiveLineNo] = updatedLine;
   }
 
   tmpDir.deleteSync(recursive: true);
@@ -716,7 +802,9 @@ analyzer:
       }
     }
     File(path).writeAsStringSync(lines.join('\n'));
-    stdout.writeln('  Updated ${lineReplacements.length} directive(s) in $path');
+    stdout.writeln(
+      '  Updated ${lineReplacements.length} directive(s) in $path',
+    );
   }
 
   return errors;
@@ -770,7 +858,9 @@ Future<void> main(List<String> args) async {
       stdout.writeln('✓ All runnable doc snippets OK for scope=$scope.');
       exit(0);
     }
-    stderr.writeln('\n✗ ${runErrors.length} runnable doc snippet issue(s) found:\n');
+    stderr.writeln(
+      '\n✗ ${runErrors.length} runnable doc snippet issue(s) found:\n',
+    );
     for (final e in runErrors) {
       stderr.writeln('  $e');
     }
@@ -785,7 +875,9 @@ Future<void> main(List<String> args) async {
     stdout.writeln('  Snapshotting doc snippets for scope=$scope…');
     final snapErrors = await _snapshotSnippets(snippets, rootDir, scope: scope);
     if (snapErrors.isEmpty) {
-      stdout.writeln('✓ Snapshot complete for scope=$scope — commit the updated directives.');
+      stdout.writeln(
+        '✓ Snapshot complete for scope=$scope — commit the updated directives.',
+      );
       exit(0);
     }
     stderr.writeln('\n✗ ${snapErrors.length} snapshot error(s):\n');

--- a/tool/check_doc_snippets.dart
+++ b/tool/check_doc_snippets.dart
@@ -158,9 +158,12 @@ class DocRunDirective {
   final String? expectStdoutContains;
   final String? expectStderrContains;
   final int expectExit;
+  /// 1-based line number of the `<!-- doc:run ... -->` comment in the source file.
+  final int directiveLineNo;
 
   const DocRunDirective({
     required this.scope,
+    required this.directiveLineNo,
     this.expectStdout,
     this.expectStdoutContains,
     this.expectStderrContains,
@@ -179,7 +182,19 @@ Map<String, String> _parseDirectiveArgs(String text) {
   return args;
 }
 
-DocRunDirective? _parseRunDirective(String line) {
+/// Unescape `\n` and `\"` sequences stored inside directive attribute values.
+String _unescapeDirectiveValue(String s) =>
+    s.replaceAll(r'\"', '"').replaceAll(r'\n', '\n');
+
+/// Escape a string for embedding inside a `"..."` directive attribute value.
+String _escapeForDirective(String s) =>
+    s.replaceAll(r'\', r'\\').replaceAll('"', r'\"').replaceAll('\n', r'\n');
+
+DocRunDirective? _parseRunDirective(
+  String line,
+  int lineNo, {
+  bool allowBare = false,
+}) {
   final trimmed = line.trim();
   if (!trimmed.startsWith('<!--') || !trimmed.endsWith('-->')) return null;
   if (!trimmed.contains('doc:run')) return null;
@@ -190,24 +205,29 @@ DocRunDirective? _parseRunDirective(String line) {
     throw FormatException('doc:run directive is missing required scope=...');
   }
 
-  final expectStdout = args['expect_stdout'];
+  final expectStdoutRaw = args['expect_stdout'];
+  final expectStdout =
+      expectStdoutRaw == null ? null : _unescapeDirectiveValue(expectStdoutRaw);
   final expectStdoutContains = args['expect_stdout_contains'];
   final expectStderrContains = args['expect_stderr_contains'];
   final expectExitRaw = args['expect_exit'];
   final expectExit =
       expectExitRaw == null ? 0 : int.parse(expectExitRaw);
 
-  if (expectStdout == null &&
+  if (!allowBare &&
+      expectStdout == null &&
       expectStdoutContains == null &&
       expectStderrContains == null &&
       expectExitRaw == null) {
     throw FormatException(
-      'doc:run directive must declare at least one expectation.',
+      'doc:run directive must declare at least one expectation '
+      '(or run with --mode=snapshot to auto-generate).',
     );
   }
 
   return DocRunDirective(
     scope: scope,
+    directiveLineNo: lineNo,
     expectStdout: expectStdout,
     expectStdoutContains: expectStdoutContains,
     expectStderrContains: expectStderrContains,
@@ -215,7 +235,7 @@ DocRunDirective? _parseRunDirective(String line) {
   );
 }
 
-List<Snippet> _extractSnippets(String rootDir) {
+List<Snippet> _extractSnippets(String rootDir, {bool allowBareDirectives = false}) {
   final results = <Snippet>[];
   final errors = <String>[];
 
@@ -242,14 +262,19 @@ List<Snippet> _extractSnippets(String rootDir) {
       } else if (inBlock && line.trim() == '```') {
         inBlock = false;
         final directiveLine = pendingDirectiveLine;
+        final directiveLineNo = pendingDirectiveLineNo;
         final nocheck = directiveLine?.contains('doc:nocheck') ?? false;
         DocRunDirective? runDirective;
         if (directiveLine != null && directiveLine.contains('doc:run')) {
           try {
-            runDirective = _parseRunDirective(directiveLine);
+            runDirective = _parseRunDirective(
+              directiveLine,
+              directiveLineNo ?? blockStart,
+              allowBare: allowBareDirectives,
+            );
           } on FormatException catch (e) {
             errors.add(
-              '$path:${pendingDirectiveLineNo ?? blockStart}: ${e.message}',
+              '$path:${directiveLineNo ?? blockStart}: ${e.message}',
             );
           }
         }
@@ -559,6 +584,144 @@ analyzer:
   return errors;
 }
 
+/// Runs each snippet for [scope] and rewrites the `<!-- doc:run ... -->`
+/// directive in the source markdown file to include `expect_stdout="<output>"`.
+///
+/// Bare directives (no expectations yet) are allowed — this is how they get
+/// their initial expected output recorded. Existing `expect_stdout=` values
+/// are overwritten with the fresh run output.
+Future<List<String>> _snapshotSnippets(
+  List<Snippet> snippets,
+  String rootDir, {
+  required String scope,
+}) async {
+  final runnable = snippets.where((s) {
+    final directive = s.runDirective;
+    if (directive == null) return false;
+    return directive.scope == scope;
+  }).toList();
+
+  if (runnable.isEmpty) {
+    stdout.writeln('  No doc:run snippets found for scope=$scope.');
+    return [];
+  }
+
+  final tmpDir = Directory.systemTemp.createTempSync('knex_dart_doc_snap_');
+  final libDir = Directory('${tmpDir.path}/lib')..createSync();
+
+  File('${tmpDir.path}/pubspec.yaml')
+      .writeAsStringSync(_buildTempPubspec(rootDir));
+  File('${tmpDir.path}/analysis_options.yaml').writeAsStringSync('''
+analyzer:
+  errors:
+    unused_import: ignore
+    unused_local_variable: ignore
+    dead_code: ignore
+    unawaited_futures: ignore
+    unnecessary_import: ignore
+''');
+
+  final fileForSnippet = <Snippet, String>{};
+  for (var i = 0; i < runnable.length; i++) {
+    final s = runnable[i];
+    final fileName = 'snippet_${i.toString().padLeft(4, '0')}.dart';
+    fileForSnippet[s] = fileName;
+    final wrapped =
+        '// SOURCE: ${s.file}:${s.startLine}\n'
+        '${buildDocSnippetProgram(s.code, target: DocSnippetTarget.local)}';
+    File('${libDir.path}/$fileName').writeAsStringSync(wrapped);
+  }
+
+  final pubGet = await Process.run(
+    'dart',
+    ['pub', 'get'],
+    workingDirectory: tmpDir.path,
+  );
+  if (pubGet.exitCode != 0) {
+    tmpDir.deleteSync(recursive: true);
+    return [
+      'ERROR: dart pub get failed in temp snapshot package:\n${pubGet.stderr}',
+    ];
+  }
+
+  final errors = <String>[];
+
+  // Group snippets by source file so we can do one file-rewrite per file.
+  final byFile = <String, List<Snippet>>{};
+  for (final s in runnable) {
+    byFile.putIfAbsent(s.file, () => []).add(s);
+  }
+  // Track mutations per file: directiveLineNo → new directive text
+  final mutations = <String, Map<int, String>>{};
+
+  for (final snippet in runnable) {
+    final directive = snippet.runDirective!;
+    final fileName = fileForSnippet[snippet]!;
+    final run = await Process.run(
+      'dart',
+      ['run', 'lib/$fileName'],
+      workingDirectory: tmpDir.path,
+    );
+
+    if (run.exitCode != 0) {
+      errors.add(
+        '${snippet.file}:${snippet.startLine}: snippet exited with code '
+        '${run.exitCode} — cannot snapshot.\nstderr:\n${run.stderr}',
+      );
+      continue;
+    }
+
+    final captured = (run.stdout as String).trimRight();
+    final escaped = _escapeForDirective(captured);
+
+    // Read the original directive line
+    final fileLines = File(snippet.file).readAsLinesSync();
+    final lineIdx = directive.directiveLineNo - 1;
+    if (lineIdx < 0 || lineIdx >= fileLines.length) {
+      errors.add(
+        '${snippet.file}: directive line ${directive.directiveLineNo} out of range',
+      );
+      continue;
+    }
+    final originalLine = fileLines[lineIdx];
+
+    String updatedLine;
+    if (originalLine.contains('expect_stdout=')) {
+      // Replace existing value — handles both quoted forms
+      updatedLine = originalLine.replaceFirst(
+        RegExp(r"""expect_stdout=("([^"]*)"|'([^']*)'|\S+)"""),
+        'expect_stdout="$escaped"',
+      );
+    } else {
+      // Insert before the closing -->
+      updatedLine = originalLine.replaceFirst(' -->', ' expect_stdout="$escaped" -->');
+    }
+
+    mutations.putIfAbsent(snippet.file, () => <int, String>{})[directive.directiveLineNo] =
+        updatedLine;
+  }
+
+  tmpDir.deleteSync(recursive: true);
+
+  // Apply all mutations, one file at a time
+  for (final entry in mutations.entries) {
+    final path = entry.key;
+    final lineReplacements = entry.value; // lineNo → new text
+    final content = File(path).readAsStringSync();
+    final lines = content.split('\n');
+    for (final lineEntry in lineReplacements.entries) {
+      final idx = lineEntry.key - 1;
+      if (idx >= 0 && idx < lines.length) {
+        lines[idx] = lineEntry.value;
+      }
+    }
+    File(path).writeAsStringSync(lines.join('\n'));
+    stdout.writeln('  Updated ${lineReplacements.length} directive(s) in $path');
+  }
+
+  return errors;
+}
+
 // ── Main ─────────────────────────────────────────────────────────────────────
 
 Future<void> main(List<String> args) async {
@@ -583,9 +746,12 @@ Future<void> main(List<String> args) async {
 
   stdout.writeln('Scanning doc snippets in $rootDir…');
 
+  // snapshot mode allows bare doc:run directives (no expectations yet).
+  final allowBare = mode == 'snapshot';
+
   late final List<Snippet> snippets;
   try {
-    snippets = _extractSnippets(rootDir);
+    snippets = _extractSnippets(rootDir, allowBareDirectives: allowBare);
   } on FormatException catch (e) {
     stderr.writeln('\n✗ doc snippet directive issue(s) found:\n');
     stderr.writeln(e.message);
@@ -594,18 +760,36 @@ Future<void> main(List<String> args) async {
   stdout.writeln('  Found ${snippets.length} dart snippets');
 
   if (mode == 'run') {
-    if (scope == null || scope!.isEmpty) {
+    if (scope == null || scope.isEmpty) {
       stderr.writeln('Missing required --scope for --mode=run');
       exit(1);
     }
     stdout.writeln('  Running doc snippets for scope=$scope…');
-    final runErrors = await _runSnippets(snippets, rootDir, scope: scope!);
+    final runErrors = await _runSnippets(snippets, rootDir, scope: scope);
     if (runErrors.isEmpty) {
       stdout.writeln('✓ All runnable doc snippets OK for scope=$scope.');
       exit(0);
     }
     stderr.writeln('\n✗ ${runErrors.length} runnable doc snippet issue(s) found:\n');
     for (final e in runErrors) {
+      stderr.writeln('  $e');
+    }
+    exit(1);
+  }
+
+  if (mode == 'snapshot') {
+    if (scope == null || scope.isEmpty) {
+      stderr.writeln('Missing required --scope for --mode=snapshot');
+      exit(1);
+    }
+    stdout.writeln('  Snapshotting doc snippets for scope=$scope…');
+    final snapErrors = await _snapshotSnippets(snippets, rootDir, scope: scope);
+    if (snapErrors.isEmpty) {
+      stdout.writeln('✓ Snapshot complete for scope=$scope — commit the updated directives.');
+      exit(0);
+    }
+    stderr.writeln('\n✗ ${snapErrors.length} snapshot error(s):\n');
+    for (final e in snapErrors) {
       stderr.writeln('  $e');
     }
     exit(1);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SQLite reactive `watch()` queries with optional debounce/max pending writes and transaction-safe re-emissions.
  * Added SQLite web/WASM persistence selection via `webStorageMode` (`memory`, `indexedDb`, `opfs`, `auto`).

* **Documentation**
  * Updated Quick Start, connection, and streaming/transactions docs with runnable `doc:run` snippets, `close()` cleanup, and new reactive examples.

* **Chores / CI**
  * Enhanced doc snippet runner with run/snapshot modes and database-scoped checks in CI, plus corresponding Makefile targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->