### PR TITLE
chore: bump deps + migrate knex_dart_lint from custom_lint to analysis_server_plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Add the driver for your database — it pulls in `knex_dart` automatically:
 
 ```yaml
 dependencies:
-  knex_dart_postgres: ^0.3.1   # PostgreSQL
+  knex_dart_postgres: ^0.3.2   # PostgreSQL
   # knex_dart_mysql: ^0.3.1    # MySQL
   # knex_dart_sqlite: ^0.4.0   # SQLite
   # knex_dart_duckdb: ^0.2.1   # DuckDB (OLAP / browser WASM)

--- a/benchmarks/bin/sqlite_live.dart
+++ b/benchmarks/bin/sqlite_live.dart
@@ -52,7 +52,7 @@ class RawBench {
     }
   }
 
-  void tearDown() => _db.dispose();
+  void tearDown() => _db.close();
 
   Future<Duration> benchSelect() => _time(() async {
     for (var i = 0; i < _iterations; i++) {

--- a/benchmarks/pubspec.yaml
+++ b/benchmarks/pubspec.yaml
@@ -13,4 +13,4 @@ dependencies:
   knex_dart_sqlite: ^0.4.0
   knex_dart_otel: ^0.1.0
   dartastic_opentelemetry_api: ^0.9.0
-  sqlite3: ^2.4.0
+  sqlite3: ^3.0.0

--- a/docs/site/pubspec.yaml
+++ b/docs/site/pubspec.yaml
@@ -18,7 +18,7 @@ dev_dependencies:
   build_runner: ^2.10.0
   build_web_compilers: ^4.4.7
   jaspr_builder: ^0.23.1
-  lints: ^5.0.0
+  lints: ^6.1.0
 
 jaspr:
   mode: static

--- a/drivers/knex_dart_bigquery/pubspec.yaml
+++ b/drivers/knex_dart_bigquery/pubspec.yaml
@@ -21,6 +21,6 @@ dependencies:
   http: ^1.2.0
 
 dev_dependencies:
-  test: ^1.25.6
-  lints: ^6.0.0
+  test: ^1.31.0
+  lints: ^6.1.0
   universal_io: ^2.2.2

--- a/drivers/knex_dart_d1/pubspec.yaml
+++ b/drivers/knex_dart_d1/pubspec.yaml
@@ -21,5 +21,5 @@ dependencies:
   http: ^1.2.0
 
 dev_dependencies:
-  test: ^1.25.6
-  lints: ^6.0.0
+  test: ^1.31.0
+  lints: ^6.1.0

--- a/drivers/knex_dart_duckdb/pubspec.yaml
+++ b/drivers/knex_dart_duckdb/pubspec.yaml
@@ -23,5 +23,5 @@ dependencies:
   universal_io: ^2.2.2
 
 dev_dependencies:
-  test: ^1.25.6
-  lints: ^6.0.0
+  test: ^1.31.0
+  lints: ^6.1.0

--- a/drivers/knex_dart_mssql/pubspec.yaml
+++ b/drivers/knex_dart_mssql/pubspec.yaml
@@ -22,5 +22,5 @@ dependencies:
   universal_io: ^2.3.1
 
 dev_dependencies:
-  test: ^1.25.6
-  lints: ^6.0.0
+  test: ^1.31.0
+  lints: ^6.1.0

--- a/drivers/knex_dart_mysql/pubspec.yaml
+++ b/drivers/knex_dart_mysql/pubspec.yaml
@@ -23,5 +23,5 @@ dependencies:
   universal_io: ^2.3.1
 
 dev_dependencies:
-  test: ^1.25.6
-  lints: ^6.0.0
+  test: ^1.31.0
+  lints: ^6.1.0

--- a/drivers/knex_dart_postgres/CHANGELOG.md
+++ b/drivers/knex_dart_postgres/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.3.2
+
+- Raised `postgres` lower bound to `^3.5.12` to pick up critical transaction
+  bug fixes: silent rollback after `ROLLBACK TO SAVEPOINT` recovery, connection
+  permanently blocked when `BEGIN` fails inside `runTx`, and undefined
+  connection state after a failed `ROLLBACK` (postgres 3.5.12).
+- Users also gain typed exceptions (`UniqueViolationException`,
+  `ForeignKeyViolationException`) and better stack traces from 3.5.x.
+
 ## 0.3.1
 
 - Tighten `knex_dart` lower bound to `^1.2.1` — `QueryInterceptor`

--- a/drivers/knex_dart_postgres/pubspec.yaml
+++ b/drivers/knex_dart_postgres/pubspec.yaml
@@ -1,6 +1,6 @@
 name: knex_dart_postgres
 description: PostgreSQL driver for knex_dart — connect and execute queries against a PostgreSQL database using the knex_dart query builder.
-version: 0.3.1
+version: 0.3.2
 repository: https://github.com/kartikey321/knex-dart
 homepage: https://github.com/kartikey321/knex-dart
 issue_tracker: https://github.com/kartikey321/knex-dart/issues
@@ -18,10 +18,10 @@ resolution: workspace
 
 dependencies:
   knex_dart: ^1.3.0
-  postgres: ^3.4.50
+  postgres: ^3.5.12
   logging: ^1.2.0
   universal_io: ^2.3.1
 
 dev_dependencies:
-  test: ^1.25.6
-  lints: ^6.0.0
+  test: ^1.31.0
+  lints: ^6.1.0

--- a/drivers/knex_dart_snowflake/pubspec.yaml
+++ b/drivers/knex_dart_snowflake/pubspec.yaml
@@ -21,5 +21,5 @@ dependencies:
   http: ^1.2.0
 
 dev_dependencies:
-  test: ^1.25.6
-  lints: ^6.0.0
+  test: ^1.31.0
+  lints: ^6.1.0

--- a/drivers/knex_dart_sqlite/benchmark/query_benchmark.dart
+++ b/drivers/knex_dart_sqlite/benchmark/query_benchmark.dart
@@ -58,7 +58,7 @@ class RawBench {
     }
   }
 
-  void tearDown() => _db.dispose();
+  void tearDown() => _db.close();
 
   Future<Duration> benchSelect() => _time(() async {
         for (var i = 0; i < _iterations; i++) {

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client.dart
@@ -126,13 +126,13 @@ class SQLiteClient extends Client {
     if (_isClosed) return;
     _isClosed = true;
     for (final stmt in _stmtCache.values) {
-      stmt.dispose();
+      stmt.close();
     }
     _stmtCache.clear();
-    // Cancel before dispose so any in-flight async events from _db.updates
+    // Cancel before close so any in-flight async events from _db.updates
     // don't reach _updateController after it is closed.
     await _updatesSub?.cancel();
-    _db.dispose();
+    _db.close();
     await _updateController.close();
   }
 
@@ -316,7 +316,7 @@ class SQLiteClient extends Client {
           );
         }
       } finally {
-        stmt.dispose();
+        stmt.close();
       }
     }
 

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
@@ -132,7 +132,7 @@ class SQLiteClient extends Client {
 
     final opened = sqlite.open(_filename);
     if (_isClosed) {
-      opened.dispose();
+      opened.close();
       return;
     }
     _db = opened;
@@ -227,7 +227,7 @@ class SQLiteClient extends Client {
       await initialize();
     } finally {
       await _updatesSub?.cancel();
-      _db?.dispose();
+      _db?.close();
       _db = null;
       _isClosed = true;
       if (!_updateController.isClosed) {
@@ -406,7 +406,7 @@ class SQLiteClient extends Client {
         yield Map<String, dynamic>.from(row);
       }
     } finally {
-      stmt.dispose();
+      stmt.close();
     }
   }
 
@@ -450,7 +450,7 @@ class SQLiteClient extends Client {
         return [];
       }
     } finally {
-      stmt.dispose();
+      stmt.close();
     }
   }
 

--- a/drivers/knex_dart_sqlite/pubspec.yaml
+++ b/drivers/knex_dart_sqlite/pubspec.yaml
@@ -18,11 +18,11 @@ resolution: workspace
 
 dependencies:
   knex_dart: ^1.3.0
-  sqlite3: ^2.4.0
-  sqlite3_web: ^0.3.0
+  sqlite3: ^3.0.0
+  sqlite3_web: ^0.9.0
   logging: ^1.2.0
   universal_io: ^2.3.1
 
 dev_dependencies:
-  test: ^1.25.6
-  lints: ^6.0.0
+  test: ^1.31.0
+  lints: ^6.1.0

--- a/drivers/knex_dart_turso/pubspec.yaml
+++ b/drivers/knex_dart_turso/pubspec.yaml
@@ -22,5 +22,5 @@ dependencies:
   universal_io: ^2.3.1
 
 dev_dependencies:
-  test: ^1.25.6
-  lints: ^6.0.0
+  test: ^1.31.0
+  lints: ^6.1.0

--- a/examples/knex_otel_sqlite_app/pubspec.yaml
+++ b/examples/knex_otel_sqlite_app/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   knex_dart_sqlite: ^0.2.0
 
 dev_dependencies:
-  lints: ^6.0.0
+  lints: ^6.1.0
 
 dependency_overrides:
   dartastic_opentelemetry_api: 1.0.0-beta.2

--- a/integrations/knex_dart_otel/pubspec.yaml
+++ b/integrations/knex_dart_otel/pubspec.yaml
@@ -21,5 +21,5 @@ dependencies:
   dartastic_opentelemetry_api: ^0.9.0
 
 dev_dependencies:
-  test: ^1.25.6
-  lints: ^6.0.0
+  test: ^1.31.0
+  lints: ^6.1.0

--- a/packages/knex_dart/README.md
+++ b/packages/knex_dart/README.md
@@ -48,7 +48,7 @@ Add the driver for your database — it pulls in `knex_dart` automatically:
 
 ```yaml
 dependencies:
-  knex_dart_postgres: ^0.3.1   # PostgreSQL
+  knex_dart_postgres: ^0.3.2   # PostgreSQL
   # knex_dart_mysql: ^0.3.1    # MySQL
   # knex_dart_sqlite: ^0.4.0   # SQLite
   # knex_dart_duckdb: ^0.2.1   # DuckDB (OLAP / browser WASM)

--- a/packages/knex_dart/pubspec.yaml
+++ b/packages/knex_dart/pubspec.yaml
@@ -18,13 +18,13 @@ resolution: workspace
 
 dependencies:
   logging: ^1.2.0
-  meta: ^1.11.0
+  meta: ^1.18.0
   collection: ^1.18.0
   knex_dart_capabilities: ^0.3.0
   universal_io: ^2.2.2
 
 dev_dependencies:
-  lints: ^6.0.0
-  test: ^1.25.6
+  lints: ^6.1.0
+  test: ^1.31.0
   analyzer: ^8.0.0
   yaml: ^3.1.0

--- a/packages/knex_dart_capabilities/pubspec.yaml
+++ b/packages/knex_dart_capabilities/pubspec.yaml
@@ -19,5 +19,5 @@ resolution: workspace
 dependencies:
 
 dev_dependencies:
-  lints: ^6.0.0
-  test: ^1.25.6
+  lints: ^6.1.0
+  test: ^1.31.0

--- a/packages/knex_dart_lint/lib/knex_dart_lint.dart
+++ b/packages/knex_dart_lint/lib/knex_dart_lint.dart
@@ -1,51 +1,13 @@
-import 'package:custom_lint_builder/custom_lint_builder.dart';
-
-// ── Dialect-capability rules ────────────────────────────────────────────────
-import 'src/rules/dialect_unsupported_full_outer_join_rule.dart';
-import 'src/rules/dialect_unsupported_lateral_join_rule.dart';
-import 'src/rules/dialect_unsupported_on_conflict_merge_rule.dart';
-import 'src/rules/dialect_unsupported_returning_rule.dart';
-// New dialect rules
-import 'src/rules/dialect_unsupported_cte_rule.dart';
-import 'src/rules/dialect_unsupported_window_functions_rule.dart';
-import 'src/rules/dialect_unsupported_json_rule.dart';
-import 'src/rules/dialect_unsupported_intersect_except_rule.dart';
-
-// ── Literal value rules ─────────────────────────────────────────────────────
-import 'src/rules/invalid_where_operator_rule.dart';
-import 'src/rules/where_null_value_rule.dart';
-import 'src/rules/invalid_order_direction_rule.dart';
-import 'src/rules/raw_null_identifier_binding_rule.dart';
-
-// ── Type-inference rules ────────────────────────────────────────────────────
-import 'src/rules/value_type_check_rules.dart';
-
-PluginBase createPlugin() => _KnexDartLintPlugin();
-
-class _KnexDartLintPlugin extends PluginBase {
-  @override
-  List<LintRule> getLintRules(CustomLintConfigs configs) {
-    return [
-      // Dialect-capability rules (8)
-      DialectUnsupportedReturningRule(),
-      DialectUnsupportedFullOuterJoinRule(),
-      DialectUnsupportedLateralJoinRule(),
-      DialectUnsupportedOnConflictMergeRule(),
-      DialectUnsupportedCteRule(),
-      DialectUnsupportedWindowFunctionsRule(),
-      DialectUnsupportedJsonRule(),
-      DialectUnsupportedIntersectExceptRule(),
-
-      // Literal value rules (4)
-      InvalidWhereOperatorRule(),
-      WhereNullValueRule(),
-      InvalidOrderDirectionRule(),
-      RawNullIdentifierBindingRule(),
-
-      // Type-inference rules (3) — WARNING severity
-      LimitNonIntArgumentRule(),
-      InsertWrongValueTypeRule(),
-      WhereNullTypedValueRule(),
-    ];
-  }
-}
+export 'src/rules/dialect_unsupported_cte_rule.dart';
+export 'src/rules/dialect_unsupported_full_outer_join_rule.dart';
+export 'src/rules/dialect_unsupported_intersect_except_rule.dart';
+export 'src/rules/dialect_unsupported_json_rule.dart';
+export 'src/rules/dialect_unsupported_lateral_join_rule.dart';
+export 'src/rules/dialect_unsupported_on_conflict_merge_rule.dart';
+export 'src/rules/dialect_unsupported_returning_rule.dart';
+export 'src/rules/dialect_unsupported_window_functions_rule.dart';
+export 'src/rules/invalid_order_direction_rule.dart';
+export 'src/rules/invalid_where_operator_rule.dart';
+export 'src/rules/raw_null_identifier_binding_rule.dart';
+export 'src/rules/value_type_check_rules.dart';
+export 'src/rules/where_null_value_rule.dart';

--- a/packages/knex_dart_lint/lib/main.dart
+++ b/packages/knex_dart_lint/lib/main.dart
@@ -1,0 +1,44 @@
+import 'package:analysis_server_plugin/plugin.dart';
+import 'package:analysis_server_plugin/registry.dart';
+
+import 'src/rules/dialect_unsupported_cte_rule.dart';
+import 'src/rules/dialect_unsupported_full_outer_join_rule.dart';
+import 'src/rules/dialect_unsupported_intersect_except_rule.dart';
+import 'src/rules/dialect_unsupported_json_rule.dart';
+import 'src/rules/dialect_unsupported_lateral_join_rule.dart';
+import 'src/rules/dialect_unsupported_on_conflict_merge_rule.dart';
+import 'src/rules/dialect_unsupported_returning_rule.dart';
+import 'src/rules/dialect_unsupported_window_functions_rule.dart';
+import 'src/rules/invalid_order_direction_rule.dart';
+import 'src/rules/invalid_where_operator_rule.dart';
+import 'src/rules/raw_null_identifier_binding_rule.dart';
+import 'src/rules/value_type_check_rules.dart';
+import 'src/rules/where_null_value_rule.dart';
+
+final plugin = _KnexDartLintPlugin();
+
+class _KnexDartLintPlugin extends Plugin {
+  @override
+  String get name => 'knex_dart_lint';
+
+  @override
+  void register(PluginRegistry registry) {
+    // Always-on warning rules.
+    registry.registerWarningRule(DialectUnsupportedReturningRule());
+    registry.registerWarningRule(DialectUnsupportedFullOuterJoinRule());
+    registry.registerWarningRule(DialectUnsupportedLateralJoinRule());
+    registry.registerWarningRule(DialectUnsupportedOnConflictMergeRule());
+    registry.registerWarningRule(DialectUnsupportedCteRule());
+    registry.registerWarningRule(DialectUnsupportedWindowFunctionsRule());
+    registry.registerWarningRule(DialectUnsupportedJsonRule());
+    registry.registerWarningRule(DialectUnsupportedIntersectExceptRule());
+    registry.registerWarningRule(InvalidWhereOperatorRule());
+    registry.registerWarningRule(InvalidOrderDirectionRule());
+    registry.registerWarningRule(RawNullIdentifierBindingRule());
+    registry.registerWarningRule(LimitNonIntArgumentRule());
+    registry.registerWarningRule(InsertWrongValueTypeRule());
+    registry.registerWarningRule(WhereNullTypedValueRule());
+    // Opt-in lint rules (enable in analysis_options.yaml diagnostics section).
+    registry.registerLintRule(WhereNullValueRule());
+  }
+}

--- a/packages/knex_dart_lint/lib/src/rule_utils.dart
+++ b/packages/knex_dart_lint/lib/src/rule_utils.dart
@@ -1,6 +1,5 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
-import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:knex_dart_capabilities/knex_dart_capabilities.dart';
 
 import 'dialect_resolution.dart';
@@ -34,8 +33,7 @@ String dialectLabel(KnexDialect dialect) {
 
 void reportIfUnsupported({
   required MethodInvocation node,
-  required DiagnosticReporter reporter,
-  required LintCode code,
+  required AnalysisRule rule,
   required SqlCapability capability,
 }) {
   final info = resolveDialectForInvocation(node);
@@ -44,5 +42,5 @@ void reportIfUnsupported({
   final dialect = info.dialect!;
   if (supportsCapability(dialect, capability)) return;
 
-  reporter.atNode(node.methodName, code, arguments: [dialectLabel(dialect)]);
+  rule.reportAtNode(node.methodName, arguments: [dialectLabel(dialect)]);
 }

--- a/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_cte_rule.dart
+++ b/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_cte_rule.dart
@@ -1,50 +1,50 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart' show DiagnosticSeverity;
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
-import 'package:custom_lint_builder/custom_lint_builder.dart';
-
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
 import 'package:knex_dart_capabilities/knex_dart_capabilities.dart';
+
 import '../rule_utils.dart';
 
-/// Lint rule: `dialect_unsupported_cte`
-///
-/// Fires when `.with_()` or `.withRecursive()` is called on a `Knex` instance
-/// whose dialect does not support CTEs.
-///
-/// CTEs are supported by PostgreSQL, MySQL 8+, and SQLite 3.35+.
-/// This rule only fires for dialects we can statically resolve.
-class DialectUnsupportedCteRule extends DartLintRule {
-  DialectUnsupportedCteRule() : super(code: _code);
-
-  static const LintCode _code = LintCode(
-    name: 'dialect_unsupported_cte',
-    problemMessage:
-        'CTEs (WITH / WITH RECURSIVE) are not supported by the resolved {0} driver.',
+class DialectUnsupportedCteRule extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'dialect_unsupported_cte',
+    'CTEs (WITH / WITH RECURSIVE) are not supported by the resolved {0} driver.',
     correctionMessage:
         'Use PostgreSQL, MySQL 8+, or SQLite 3.35+ for CTE support.',
-    errorSeverity: DiagnosticSeverity.WARNING,
+    severity: DiagnosticSeverity.WARNING,
+    uniqueName: 'knex_dart_lint.dialect_unsupported_cte',
   );
 
-  // NOTE: All three currently-supported dialects (postgres, mysql, sqlite)
-  // include `cte` in the capability matrix, so this rule is inert for now.
-  // It will fire if older dialect variants (e.g. MySQL 5.6) are added later.
-  static const _targetMethods = {'withQuery', 'withRecursive'};
+  DialectUnsupportedCteRule()
+    : super(
+        name: 'dialect_unsupported_cte',
+        description: 'CTEs are not supported by all drivers.',
+      );
 
   @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
-  ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      if (!_targetMethods.contains(node.methodName.name)) return;
+  DiagnosticCode get diagnosticCode => code;
 
-      reportIfUnsupported(
-        node: node,
-        reporter: reporter,
-        code: _code,
-        capability: SqlCapability.cte,
-      );
-    });
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    registry.addMethodInvocation(this, _Visitor(this));
+  }
+}
+
+const _cteTargetMethods = {'withQuery', 'withRecursive'};
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _Visitor(this.rule);
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (!_cteTargetMethods.contains(node.methodName.name)) return;
+    reportIfUnsupported(node: node, rule: rule, capability: SqlCapability.cte);
   }
 }

--- a/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_full_outer_join_rule.dart
+++ b/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_full_outer_join_rule.dart
@@ -1,37 +1,51 @@
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
-import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart' show DiagnosticSeverity;
-
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
 import 'package:knex_dart_capabilities/knex_dart_capabilities.dart';
+
 import '../rule_utils.dart';
 
-class DialectUnsupportedFullOuterJoinRule extends DartLintRule {
-  DialectUnsupportedFullOuterJoinRule() : super(code: _code);
-
-  static const LintCode _code = LintCode(
-    name: 'dialect_unsupported_full_outer_join',
-    problemMessage:
-        'FULL OUTER JOIN is not supported by the resolved {0} driver.',
+class DialectUnsupportedFullOuterJoinRule extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'dialect_unsupported_full_outer_join',
+    'FULL OUTER JOIN is not supported by the resolved {0} driver.',
     correctionMessage: 'Consider LEFT JOIN + UNION strategy where appropriate.',
-    errorSeverity: DiagnosticSeverity.WARNING,
+    severity: DiagnosticSeverity.WARNING,
+    uniqueName: 'knex_dart_lint.dialect_unsupported_full_outer_join',
   );
 
-  @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
-  ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      if (node.methodName.name != 'fullOuterJoin') return;
-
-      reportIfUnsupported(
-        node: node,
-        reporter: reporter,
-        code: _code,
-        capability: SqlCapability.fullOuterJoin,
+  DialectUnsupportedFullOuterJoinRule()
+    : super(
+        name: 'dialect_unsupported_full_outer_join',
+        description: 'FULL OUTER JOIN is not supported by all drivers.',
       );
-    });
+
+  @override
+  DiagnosticCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    registry.addMethodInvocation(this, _Visitor(this));
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _Visitor(this.rule);
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.methodName.name != 'fullOuterJoin') return;
+    reportIfUnsupported(
+      node: node,
+      rule: rule,
+      capability: SqlCapability.fullOuterJoin,
+    );
   }
 }

--- a/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_intersect_except_rule.dart
+++ b/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_intersect_except_rule.dart
@@ -1,53 +1,55 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart' show DiagnosticSeverity;
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
-import 'package:custom_lint_builder/custom_lint_builder.dart';
-
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
 import 'package:knex_dart_capabilities/knex_dart_capabilities.dart';
+
 import '../rule_utils.dart';
 
-/// Lint rule: `dialect_unsupported_intersect_except`
-///
-/// Fires when `.intersect()` or `.except()` is called on a `Knex` instance
-/// whose resolved dialect does not support INTERSECT / EXCEPT set operations.
-///
-/// Supported: PostgreSQL, SQLite.
-/// Not reliably supported: MySQL (requires 8.0.31+, not yet in the matrix).
-class DialectUnsupportedIntersectExceptRule extends DartLintRule {
-  DialectUnsupportedIntersectExceptRule() : super(code: _code);
-
-  static const LintCode _code = LintCode(
-    name: 'dialect_unsupported_intersect_except',
-    problemMessage:
-        'INTERSECT / EXCEPT are not supported by the resolved {0} driver.',
+class DialectUnsupportedIntersectExceptRule extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'dialect_unsupported_intersect_except',
+    'INTERSECT / EXCEPT are not supported by the resolved {0} driver.',
     correctionMessage:
         'Use PostgreSQL or SQLite for INTERSECT/EXCEPT. '
         'MySQL requires 8.0.31+ and is not currently in the support matrix.',
-    errorSeverity: DiagnosticSeverity.WARNING,
+    severity: DiagnosticSeverity.WARNING,
+    uniqueName: 'knex_dart_lint.dialect_unsupported_intersect_except',
   );
 
-  static const _targetMethods = {
-    'intersect',
-    'intersectAll',
-    'except',
-    'exceptAll',
-  };
+  DialectUnsupportedIntersectExceptRule()
+    : super(
+        name: 'dialect_unsupported_intersect_except',
+        description: 'INTERSECT/EXCEPT are not supported by all drivers.',
+      );
 
   @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
-  ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      if (!_targetMethods.contains(node.methodName.name)) return;
+  DiagnosticCode get diagnosticCode => code;
 
-      reportIfUnsupported(
-        node: node,
-        reporter: reporter,
-        code: _code,
-        capability: SqlCapability.intersectExcept,
-      );
-    });
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    registry.addMethodInvocation(this, _Visitor(this));
+  }
+}
+
+const _intersectExceptMethods = {'intersect', 'intersectAll', 'except', 'exceptAll'};
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _Visitor(this.rule);
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (!_intersectExceptMethods.contains(node.methodName.name)) return;
+    reportIfUnsupported(
+      node: node,
+      rule: rule,
+      capability: SqlCapability.intersectExcept,
+    );
   }
 }

--- a/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_json_rule.dart
+++ b/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_json_rule.dart
@@ -1,59 +1,64 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart' show DiagnosticSeverity;
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
-import 'package:custom_lint_builder/custom_lint_builder.dart';
-
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
 import 'package:knex_dart_capabilities/knex_dart_capabilities.dart';
+
 import '../rule_utils.dart';
 
-/// Lint rule: `dialect_unsupported_json`
-///
-/// Fires when JSON-specific query methods are called on a `Knex` instance
-/// whose resolved dialect does not support JSON operators.
-///
-/// Full JSON support: PostgreSQL only.
-/// Partial support (JSON path functions only): MySQL 5.7+.
-/// Not supported: SQLite.
-class DialectUnsupportedJsonRule extends DartLintRule {
-  DialectUnsupportedJsonRule() : super(code: _code);
-
-  static const LintCode _code = LintCode(
-    name: 'dialect_unsupported_json',
-    problemMessage:
-        'JSON operators/functions are not supported by the resolved {0} driver.',
+class DialectUnsupportedJsonRule extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'dialect_unsupported_json',
+    'JSON operators/functions are not supported by the resolved {0} driver.',
     correctionMessage:
         'Use PostgreSQL for full JSON support, or MySQL 5.7+ for basic JSON functions. '
         'SQLite has no native JSON type.',
-    errorSeverity: DiagnosticSeverity.WARNING,
+    severity: DiagnosticSeverity.WARNING,
+    uniqueName: 'knex_dart_lint.dialect_unsupported_json',
   );
 
-  // Only methods that actually exist on QueryBuilder / JsonQueryBuilder extension.
-  static const _targetMethods = {
-    'whereJsonObject',
-    'orWhereJsonObject',
-    'whereJsonPath',
-    'orWhereJsonPath',
-    'whereJsonSupersetOf',
-    'orWhereJsonSupersetOf',
-    'whereJsonSubsetOf',
-    'orWhereJsonSubsetOf',
-  };
+  DialectUnsupportedJsonRule()
+    : super(
+        name: 'dialect_unsupported_json',
+        description: 'JSON operators are not supported by all drivers.',
+      );
 
   @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
-  ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      if (!_targetMethods.contains(node.methodName.name)) return;
+  DiagnosticCode get diagnosticCode => code;
 
-      reportIfUnsupported(
-        node: node,
-        reporter: reporter,
-        code: _code,
-        capability: SqlCapability.json,
-      );
-    });
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    registry.addMethodInvocation(this, _Visitor(this));
+  }
+}
+
+const _jsonMethods = {
+  'whereJsonObject',
+  'orWhereJsonObject',
+  'whereJsonPath',
+  'orWhereJsonPath',
+  'whereJsonSupersetOf',
+  'orWhereJsonSupersetOf',
+  'whereJsonSubsetOf',
+  'orWhereJsonSubsetOf',
+};
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _Visitor(this.rule);
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (!_jsonMethods.contains(node.methodName.name)) return;
+    reportIfUnsupported(
+      node: node,
+      rule: rule,
+      capability: SqlCapability.json,
+    );
   }
 }

--- a/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_lateral_join_rule.dart
+++ b/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_lateral_join_rule.dart
@@ -1,41 +1,52 @@
-import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart' show DiagnosticSeverity;
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
-
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
 import 'package:knex_dart_capabilities/knex_dart_capabilities.dart';
+
 import '../rule_utils.dart';
 
-class DialectUnsupportedLateralJoinRule extends DartLintRule {
-  DialectUnsupportedLateralJoinRule() : super(code: _code);
-
-  static const LintCode _code = LintCode(
-    name: 'dialect_unsupported_lateral_join',
-    problemMessage: 'LATERAL JOIN is not supported by the resolved {0} driver.',
-    errorSeverity: DiagnosticSeverity.WARNING,
+class DialectUnsupportedLateralJoinRule extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'dialect_unsupported_lateral_join',
+    'LATERAL JOIN is not supported by the resolved {0} driver.',
+    severity: DiagnosticSeverity.WARNING,
+    uniqueName: 'knex_dart_lint.dialect_unsupported_lateral_join',
   );
 
-  static const Set<String> _methods = {
-    'joinLateral',
-    'leftJoinLateral',
-    'crossJoinLateral',
-  };
+  DialectUnsupportedLateralJoinRule()
+    : super(
+        name: 'dialect_unsupported_lateral_join',
+        description: 'LATERAL JOIN is not supported by all drivers.',
+      );
 
   @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
-  ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      if (!_methods.contains(node.methodName.name)) return;
+  DiagnosticCode get diagnosticCode => code;
 
-      reportIfUnsupported(
-        node: node,
-        reporter: reporter,
-        code: _code,
-        capability: SqlCapability.lateralJoin,
-      );
-    });
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    registry.addMethodInvocation(this, _Visitor(this));
+  }
+}
+
+const _lateralJoinMethods = {'joinLateral', 'leftJoinLateral', 'crossJoinLateral'};
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _Visitor(this.rule);
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (!_lateralJoinMethods.contains(node.methodName.name)) return;
+    reportIfUnsupported(
+      node: node,
+      rule: rule,
+      capability: SqlCapability.lateralJoin,
+    );
   }
 }

--- a/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_on_conflict_merge_rule.dart
+++ b/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_on_conflict_merge_rule.dart
@@ -1,40 +1,54 @@
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
-import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart' show DiagnosticSeverity;
-
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
 import 'package:knex_dart_capabilities/knex_dart_capabilities.dart';
+
 import '../dialect_resolution.dart';
 import '../rule_utils.dart';
 
-class DialectUnsupportedOnConflictMergeRule extends DartLintRule {
-  DialectUnsupportedOnConflictMergeRule() : super(code: _code);
-
-  static const LintCode _code = LintCode(
-    name: 'dialect_unsupported_on_conflict_merge',
-    problemMessage:
-        'onConflict().merge() is not supported by the resolved {0} driver.',
+class DialectUnsupportedOnConflictMergeRule extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'dialect_unsupported_on_conflict_merge',
+    'onConflict().merge() is not supported by the resolved {0} driver.',
     correctionMessage:
         'Use dialect-specific upsert support available for your driver or refactor query strategy.',
-    errorSeverity: DiagnosticSeverity.WARNING,
+    severity: DiagnosticSeverity.WARNING,
+    uniqueName: 'knex_dart_lint.dialect_unsupported_on_conflict_merge',
   );
 
-  @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
-  ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      if (node.methodName.name != 'merge') return;
-      if (!hasOnConflictInChain(node)) return;
-
-      reportIfUnsupported(
-        node: node,
-        reporter: reporter,
-        code: _code,
-        capability: SqlCapability.onConflictMerge,
+  DialectUnsupportedOnConflictMergeRule()
+    : super(
+        name: 'dialect_unsupported_on_conflict_merge',
+        description: 'onConflict().merge() is not supported by all drivers.',
       );
-    });
+
+  @override
+  DiagnosticCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    registry.addMethodInvocation(this, _Visitor(this));
+  }
+}
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _Visitor(this.rule);
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.methodName.name != 'merge') return;
+    if (!hasOnConflictInChain(node)) return;
+    reportIfUnsupported(
+      node: node,
+      rule: rule,
+      capability: SqlCapability.onConflictMerge,
+    );
   }
 }

--- a/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_returning_rule.dart
+++ b/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_returning_rule.dart
@@ -1,65 +1,76 @@
-import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart' show DiagnosticSeverity;
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
-
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
 import 'package:knex_dart_capabilities/knex_dart_capabilities.dart';
+
 import '../rule_utils.dart';
 
-class DialectUnsupportedReturningRule extends DartLintRule {
-  DialectUnsupportedReturningRule() : super(code: _code);
-
-  static const LintCode _code = LintCode(
-    name: 'dialect_unsupported_returning',
-    problemMessage:
-        'The .returning() method is not supported by the resolved {0} driver.',
+class DialectUnsupportedReturningRule extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'dialect_unsupported_returning',
+    'The .returning() method is not supported by the resolved {0} driver.',
     correctionMessage:
         'Use PostgreSQL for RETURNING support or refactor to a follow-up SELECT.',
-    errorSeverity: DiagnosticSeverity.WARNING,
+    severity: DiagnosticSeverity.WARNING,
+    uniqueName: 'knex_dart_lint.dialect_unsupported_returning',
   );
 
-  // Methods that accept an optional `returning` list as their last argument.
-  static const _methodsWithReturningArg = {'insert', 'update', 'delete'};
+  DialectUnsupportedReturningRule()
+    : super(
+        name: 'dialect_unsupported_returning',
+        description: 'RETURNING is not supported by all drivers.',
+      );
 
   @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
+  DiagnosticCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
   ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      // .returning([...]) chained call
-      if (node.methodName.name == 'returning') {
-        reportIfUnsupported(
-          node: node,
-          reporter: reporter,
-          code: _code,
-          capability: SqlCapability.returning,
-        );
-        return;
-      }
+    registry.addMethodInvocation(this, _Visitor(this));
+  }
+}
 
-      // insert(values, returning), update(values, returning), delete(returning)
-      if (!_methodsWithReturningArg.contains(node.methodName.name)) return;
-      final args = node.argumentList.arguments;
-      if (args.isEmpty) return;
-      final lastArg = args.last;
-      // Only flag when a non-null returning argument is explicitly provided.
-      if (lastArg is NullLiteral) return;
-      final isNamedReturning =
-          lastArg is NamedExpression && lastArg.name.label.name == 'returning';
-      final isPositionalReturning =
-          lastArg is! NamedExpression &&
-          ((node.methodName.name == 'delete' && args.length == 1) ||
-           (node.methodName.name != 'delete' && args.length >= 2));
-      if (!isNamedReturning && !isPositionalReturning) return;
+const _methodsWithReturningArg = {'insert', 'update', 'delete'};
 
+class _Visitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _Visitor(this.rule);
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.methodName.name == 'returning') {
       reportIfUnsupported(
         node: node,
-        reporter: reporter,
-        code: _code,
+        rule: rule,
         capability: SqlCapability.returning,
       );
-    });
+      return;
+    }
+
+    if (!_methodsWithReturningArg.contains(node.methodName.name)) return;
+    final args = node.argumentList.arguments;
+    if (args.isEmpty) return;
+    final lastArg = args.last;
+    if (lastArg is NullLiteral) return;
+    final isNamedReturning =
+        lastArg is NamedExpression &&
+        lastArg.name.label.name == 'returning';
+    final isPositionalReturning =
+        lastArg is! NamedExpression &&
+        ((node.methodName.name == 'delete' && args.length == 1) ||
+            (node.methodName.name != 'delete' && args.length >= 2));
+    if (!isNamedReturning && !isPositionalReturning) return;
+
+    reportIfUnsupported(
+      node: node,
+      rule: rule,
+      capability: SqlCapability.returning,
+    );
   }
 }

--- a/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_window_functions_rule.dart
+++ b/packages/knex_dart_lint/lib/src/rules/dialect_unsupported_window_functions_rule.dart
@@ -1,58 +1,63 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart' show DiagnosticSeverity;
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
-import 'package:custom_lint_builder/custom_lint_builder.dart';
-
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
 import 'package:knex_dart_capabilities/knex_dart_capabilities.dart';
+
 import '../rule_utils.dart';
 
-/// Lint rule: `dialect_unsupported_window_functions`
-///
-/// Fires when `.over()` or `.analytic()` is called on a `Knex` instance
-/// whose resolved dialect does not support window functions.
-///
-/// Window functions are supported in PostgreSQL, MySQL 8+, and SQLite 3.25+.
-class DialectUnsupportedWindowFunctionsRule extends DartLintRule {
-  DialectUnsupportedWindowFunctionsRule() : super(code: _code);
-
-  static const LintCode _code = LintCode(
-    name: 'dialect_unsupported_window_functions',
-    problemMessage:
-        'Window functions (OVER / PARTITION BY) are not supported by the resolved {0} driver.',
+class DialectUnsupportedWindowFunctionsRule extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'dialect_unsupported_window_functions',
+    'Window functions (OVER / PARTITION BY) are not supported by the resolved {0} driver.',
     correctionMessage:
         'Use PostgreSQL, MySQL 8+, or SQLite 3.25+ for window function support.',
-    errorSeverity: DiagnosticSeverity.WARNING,
+    severity: DiagnosticSeverity.WARNING,
+    uniqueName: 'knex_dart_lint.dialect_unsupported_window_functions',
   );
 
-  // NOTE: All three currently-supported dialects include `windowFunctions` in
-  // the capability matrix, so this rule is inert for now.
-  // It will fire if older dialect variants (e.g. MySQL 5.7) are added later.
-  static const _targetMethods = {
-    'rowNumber',
-    'rank',
-    'denseRank',
-    'lead',
-    'lag',
-    'firstValue',
-    'lastValue',
-    'nthValue',
-  };
+  DialectUnsupportedWindowFunctionsRule()
+    : super(
+        name: 'dialect_unsupported_window_functions',
+        description: 'Window functions are not supported by all drivers.',
+      );
 
   @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
-  ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      if (!_targetMethods.contains(node.methodName.name)) return;
+  DiagnosticCode get diagnosticCode => code;
 
-      reportIfUnsupported(
-        node: node,
-        reporter: reporter,
-        code: _code,
-        capability: SqlCapability.windowFunctions,
-      );
-    });
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    registry.addMethodInvocation(this, _Visitor(this));
+  }
+}
+
+const _windowFunctionMethods = {
+  'rowNumber',
+  'rank',
+  'denseRank',
+  'lead',
+  'lag',
+  'firstValue',
+  'lastValue',
+  'nthValue',
+};
+
+class _Visitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _Visitor(this.rule);
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (!_windowFunctionMethods.contains(node.methodName.name)) return;
+    reportIfUnsupported(
+      node: node,
+      rule: rule,
+      capability: SqlCapability.windowFunctions,
+    );
   }
 }

--- a/packages/knex_dart_lint/lib/src/rules/invalid_order_direction_rule.dart
+++ b/packages/knex_dart_lint/lib/src/rules/invalid_order_direction_rule.dart
@@ -1,64 +1,60 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart' show DiagnosticSeverity;
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
-import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
 
-/// Valid order direction strings — exact case required.
 const _validDirections = {'asc', 'desc'};
 
-/// Lint rule: `invalid_order_direction`
-///
-/// Fires when `.orderBy(col, dir)` or `.orderByRaw(sql, dir)` is called with
-/// a string-literal direction that is not `'asc'` or `'desc'`.
-///
-/// Catches common mistakes like `'ASC'` (uppercase) or `'ascending'`.
-///
-/// ```dart
-/// // ❌ Flagged — wrong casing / spelling
-/// db('users').orderBy('name', 'ASC');
-/// db('users').orderBy('name', 'ascending');
-///
-/// // ✅ Correct — lowercase
-/// db('users').orderBy('name', 'asc');
-/// db('users').orderBy('name', 'desc');
-/// ```
-class InvalidOrderDirectionRule extends DartLintRule {
-  InvalidOrderDirectionRule() : super(code: _code);
-
-  static const LintCode _code = LintCode(
-    name: 'invalid_order_direction',
-    problemMessage:
-        '"{0}" is not a valid sort direction. Use "asc" or "desc" (lowercase).',
+class InvalidOrderDirectionRule extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'invalid_order_direction',
+    '"{0}" is not a valid sort direction. Use "asc" or "desc" (lowercase).',
     correctionMessage:
         'Replace with "asc" or "desc". knex_dart is case-sensitive '
         'for order directions.',
-    errorSeverity: DiagnosticSeverity.WARNING,
+    severity: DiagnosticSeverity.WARNING,
+    uniqueName: 'knex_dart_lint.invalid_order_direction',
   );
 
-  static const _targetMethods = {'orderBy'};
+  InvalidOrderDirectionRule()
+    : super(
+        name: 'invalid_order_direction',
+        description: 'Flags invalid orderBy direction strings.',
+      );
 
   @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
+  DiagnosticCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
   ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      if (!_targetMethods.contains(node.methodName.name)) return;
+    registry.addMethodInvocation(this, _Visitor(this));
+  }
+}
 
-      final args = node.argumentList.arguments;
-      // orderBy(col, direction) — direction is the second positional arg
-      if (args.length < 2) return;
+class _Visitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _Visitor(this.rule);
 
-      final dirArg = args[1];
-      if (dirArg is! StringLiteral) return;
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.methodName.name != 'orderBy') return;
 
-      final dir = dirArg.stringValue;
-      if (dir == null) return;
+    final args = node.argumentList.arguments;
+    if (args.length < 2) return;
 
-      if (!_validDirections.contains(dir)) {
-        reporter.atNode(dirArg, _code, arguments: [dir]);
-      }
-    });
+    final dirArg = args[1];
+    if (dirArg is! StringLiteral) return;
+
+    final dir = dirArg.stringValue;
+    if (dir == null) return;
+
+    if (!_validDirections.contains(dir)) {
+      rule.reportAtNode(dirArg, arguments: [dir]);
+    }
   }
 }

--- a/packages/knex_dart_lint/lib/src/rules/invalid_where_operator_rule.dart
+++ b/packages/knex_dart_lint/lib/src/rules/invalid_where_operator_rule.dart
@@ -1,9 +1,10 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart' show DiagnosticSeverity;
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
-import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
 
-/// Set of valid SQL comparison operators (lowercased).
 const _validOps = {
   '=',
   '!=',
@@ -31,64 +32,57 @@ const _validOps = {
   '!~~*',
 };
 
-/// Lint rule: `invalid_where_operator`
-///
-/// Fires when `.where(col, op, val)` or `.having(col, op, val)` is called with
-/// a string-literal operator that is not a recognised SQL operator.
-///
-/// Catches the most common JS-to-Dart mistake: using `'=='` instead of `'='`.
-///
-/// ```dart
-/// // ❌ Flagged — '==' is not a valid SQL operator
-/// db('users').where('age', '==', 18);
-///
-/// // ✅ Correct
-/// db('users').where('age', '=', 18);
-/// db('users').where('age', Op.eq, 18);
-/// ```
-class InvalidWhereOperatorRule extends DartLintRule {
-  InvalidWhereOperatorRule() : super(code: _code);
+const _whereHavingMethods = {'where', 'orWhere', 'andWhere', 'having', 'orHaving'};
 
-  static const LintCode _code = LintCode(
-    name: 'invalid_where_operator',
-    problemMessage: '"{0}" is not a recognised SQL comparison operator.',
+class InvalidWhereOperatorRule extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'invalid_where_operator',
+    '"{0}" is not a recognised SQL comparison operator.',
     correctionMessage:
         'Use a valid SQL operator such as =, <>, !=, <, >, <=, >=, like, '
         'not like, ilike, in, not in, between, is, is not — '
         'or an Op constant (Op.eq, Op.gt, Op.like, ...).',
-    errorSeverity: DiagnosticSeverity.WARNING,
+    severity: DiagnosticSeverity.WARNING,
+    uniqueName: 'knex_dart_lint.invalid_where_operator',
   );
 
-  static const _targetMethods = {
-    'where',
-    'orWhere',
-    'andWhere',
-    'having',
-    'orHaving',
-  };
+  InvalidWhereOperatorRule()
+    : super(
+        name: 'invalid_where_operator',
+        description: 'Flags unrecognised SQL comparison operators.',
+      );
 
   @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
+  DiagnosticCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
   ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      if (!_targetMethods.contains(node.methodName.name)) return;
+    registry.addMethodInvocation(this, _Visitor(this));
+  }
+}
 
-      final args = node.argumentList.arguments;
-      // 3-arg form: where(col, op, val)
-      if (args.length < 3) return;
+class _Visitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _Visitor(this.rule);
 
-      final opArg = args[1];
-      if (opArg is! StringLiteral) return;
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (!_whereHavingMethods.contains(node.methodName.name)) return;
 
-      final op = opArg.stringValue?.toLowerCase();
-      if (op == null) return;
+    final args = node.argumentList.arguments;
+    if (args.length < 3) return;
 
-      if (!_validOps.contains(op)) {
-        reporter.atNode(opArg, _code, arguments: [opArg.stringValue ?? op]);
-      }
-    });
+    final opArg = args[1];
+    if (opArg is! StringLiteral) return;
+
+    final op = opArg.stringValue?.toLowerCase();
+    if (op == null) return;
+
+    if (!_validOps.contains(op)) {
+      rule.reportAtNode(opArg, arguments: [opArg.stringValue ?? op]);
+    }
   }
 }

--- a/packages/knex_dart_lint/lib/src/rules/raw_null_identifier_binding_rule.dart
+++ b/packages/knex_dart_lint/lib/src/rules/raw_null_identifier_binding_rule.dart
@@ -1,71 +1,67 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart' show DiagnosticSeverity;
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
-import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
 
-/// Lint rule: `raw_null_identifier_binding`
-///
-/// Fires when a named `:key:` identifier binding in a `raw()` call is
-/// assigned a `null` value.
-///
-/// `:key:` bindings expand to a quoted identifier in the SQL — they are
-/// **never** emitted as a positional parameter.  Passing `null` for an
-/// identifier binding silently leaves the original `:key:` placeholder
-/// in the SQL, producing invalid SQL at runtime.
-///
-/// ```dart
-/// // ❌ Flagged — :table: stays unresolved; SQL becomes 'SELECT * FROM :table:'
-/// db.rawSql('SELECT * FROM :table:', {'table': null});
-///
-/// // ✅ Use a real table name or omit the binding entirely
-/// db.rawSql('SELECT * FROM :table:', {'table': 'users'});
-/// ```
-class RawNullIdentifierBindingRule extends DartLintRule {
-  RawNullIdentifierBindingRule() : super(code: _code);
+const _rawMethods = {'raw', 'rawSql', 'whereRaw', 'havingRaw', 'orderByRaw', 'groupByRaw'};
 
-  static const LintCode _code = LintCode(
-    name: 'raw_null_identifier_binding',
-    problemMessage:
-        'Null value for identifier binding :{0}: — the placeholder will '
+class RawNullIdentifierBindingRule extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'raw_null_identifier_binding',
+    'Null value for identifier binding :{0}: — the placeholder will '
         'stay unresolved and produce invalid SQL.',
     correctionMessage:
         'Provide a non-null string for identifier bindings, or remove the key.',
-    errorSeverity: DiagnosticSeverity.WARNING,
+    severity: DiagnosticSeverity.WARNING,
+    uniqueName: 'knex_dart_lint.raw_null_identifier_binding',
   );
 
-  static const _rawMethods = {'raw', 'rawSql', 'whereRaw', 'havingRaw', 'orderByRaw', 'groupByRaw'};
+  RawNullIdentifierBindingRule()
+    : super(
+        name: 'raw_null_identifier_binding',
+        description: 'Flags null values for :key: identifier bindings in raw SQL.',
+      );
 
   @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
+  DiagnosticCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
   ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      if (!_rawMethods.contains(node.methodName.name)) return;
+    registry.addMethodInvocation(this, _Visitor(this));
+  }
+}
 
-      final args = node.argumentList.arguments;
-      if (args.length < 2) return;
+class _Visitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _Visitor(this.rule);
 
-      // Second argument must be a map literal: {'key': value, ...}
-      final mapArg = args[1];
-      if (mapArg is! SetOrMapLiteral) return;
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (!_rawMethods.contains(node.methodName.name)) return;
 
-      for (final element in mapArg.elements) {
-        if (element is! MapLiteralEntry) continue;
-        final key = element.key;
-        final value = element.value;
+    final args = node.argumentList.arguments;
+    if (args.length < 2) return;
 
-        // Key must be a string literal ending with ':' (identifier binding)
-        if (key is! SimpleStringLiteral) continue;
-        final keyStr = key.value.trim();
-        if (!keyStr.endsWith(':')) continue;
+    final mapArg = args[1];
+    if (mapArg is! SetOrMapLiteral) return;
 
-        // Value is a null literal — this binding will stay unresolved.
-        if (value is NullLiteral) {
-          reporter.atNode(value, _code, arguments: [keyStr]);
-        }
+    for (final element in mapArg.elements) {
+      if (element is! MapLiteralEntry) continue;
+      final key = element.key;
+      final value = element.value;
+
+      if (key is! SimpleStringLiteral) continue;
+      final keyStr = key.value.trim();
+      if (!keyStr.endsWith(':')) continue;
+
+      if (value is NullLiteral) {
+        rule.reportAtNode(value, arguments: [keyStr]);
       }
-    });
+    }
   }
 }

--- a/packages/knex_dart_lint/lib/src/rules/value_type_check_rules.dart
+++ b/packages/knex_dart_lint/lib/src/rules/value_type_check_rules.dart
@@ -1,173 +1,170 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
 import 'package:analyzer/dart/element/type.dart';
-import 'package:analyzer/error/error.dart' show DiagnosticSeverity;
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
-import 'package:custom_lint_builder/custom_lint_builder.dart';
-
-/// Lint rules that use type inference to catch type-mismatch arguments.
-///
-/// Only fires when the static type is concretely and provably wrong.
-/// Stays silent for `dynamic` arguments to avoid false positives.
+import 'package:analyzer/error/error.dart';
 
 // ─────────────────────────────────────────────────────────────────────────────
-/// Lint rule: `limit_non_int_argument`
-///
-/// Fires when `.limit()` or `.offset()` is called with a value whose
-/// static type is definitely not `int`.
-///
-/// ```dart
-/// final n = '10';          // String
-/// db('users').limit(n);    // ❌ String passed to limit()
-///
-/// // ✅ Correct
-/// db('users').limit(10);
-/// db('users').limit(int.parse(n));
-/// ```
-class LimitNonIntArgumentRule extends DartLintRule {
-  LimitNonIntArgumentRule() : super(code: _code);
 
-  static const LintCode _code = LintCode(
-    name: 'limit_non_int_argument',
-    problemMessage: '.{0}() expects an int argument, but a {1} was passed.',
+class LimitNonIntArgumentRule extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'limit_non_int_argument',
+    '.{0}() expects an int argument, but a {1} was passed.',
     correctionMessage:
         'Pass an integer literal or convert with int.parse() / .toInt().',
-    errorSeverity: DiagnosticSeverity.WARNING,
+    severity: DiagnosticSeverity.WARNING,
+    uniqueName: 'knex_dart_lint.limit_non_int_argument',
   );
+
+  LimitNonIntArgumentRule()
+    : super(
+        name: 'limit_non_int_argument',
+        description: 'Flags non-int arguments passed to .limit() or .offset().',
+      );
+
+  @override
+  DiagnosticCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
+  ) {
+    registry.addMethodInvocation(this, _LimitNonIntVisitor(this));
+  }
+}
+
+class _LimitNonIntVisitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _LimitNonIntVisitor(this.rule);
 
   static const _targetMethods = {'limit', 'offset'};
 
   @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
-  ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      final method = node.methodName.name;
-      if (!_targetMethods.contains(method)) return;
+  void visitMethodInvocation(MethodInvocation node) {
+    final method = node.methodName.name;
+    if (!_targetMethods.contains(method)) return;
 
-      final args = node.argumentList.arguments;
-      if (args.isEmpty) return;
+    final args = node.argumentList.arguments;
+    if (args.isEmpty) return;
 
-      final arg = args.first;
-      final type = arg.staticType;
-      if (type == null || type is DynamicType) return;
+    final arg = args.first;
+    final type = arg.staticType;
+    if (type == null || type is DynamicType) return;
 
-      if (!type.isDartCoreInt) {
-        reporter.atNode(
-          arg,
-          _code,
-          arguments: [method, type.getDisplayString()],
-        );
-      }
-    });
+    if (!type.isDartCoreInt) {
+      rule.reportAtNode(arg, arguments: [method, type.getDisplayString()]);
+    }
   }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-/// Lint rule: `insert_wrong_value_type`
-///
-/// Fires when `.insert()` is called with a value whose static type is
-/// neither `Map` nor `List`.
-///
-/// ```dart
-/// db('users').insert('name=John');  // ❌ String is wrong
-///
-/// // ✅ Correct
-/// db('users').insert({'name': 'John'});
-/// db('users').insert([{'name': 'Alice'}, {'name': 'Bob'}]);
-/// ```
-class InsertWrongValueTypeRule extends DartLintRule {
-  InsertWrongValueTypeRule() : super(code: _code);
 
-  static const LintCode _code = LintCode(
-    name: 'insert_wrong_value_type',
-    problemMessage:
-        '.insert() expects a Map<String, dynamic> or List<Map>, but a {0} was passed.',
+class InsertWrongValueTypeRule extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'insert_wrong_value_type',
+    '.insert() expects a Map<String, dynamic> or List<Map>, but a {0} was passed.',
     correctionMessage:
         'Pass a map of column→value pairs, or a list of such maps for batch inserts.',
-    errorSeverity: DiagnosticSeverity.WARNING,
+    severity: DiagnosticSeverity.WARNING,
+    uniqueName: 'knex_dart_lint.insert_wrong_value_type',
   );
 
+  InsertWrongValueTypeRule()
+    : super(
+        name: 'insert_wrong_value_type',
+        description: 'Flags wrong value types passed to .insert().',
+      );
+
   @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
+  DiagnosticCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
   ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      if (node.methodName.name != 'insert') return;
+    registry.addMethodInvocation(this, _InsertVisitor(this));
+  }
+}
 
-      final args = node.argumentList.arguments;
-      if (args.isEmpty) return;
+class _InsertVisitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _InsertVisitor(this.rule);
 
-      final arg = args.first;
-      final type = arg.staticType;
-      if (type == null || type is DynamicType) return;
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (node.methodName.name != 'insert') return;
 
-      final isMap = type.isDartCoreMap;
-      final isList = type.isDartCoreList;
-      if (!isMap && !isList) {
-        reporter.atNode(arg, _code, arguments: [type.getDisplayString()]);
-      }
-    });
+    final args = node.argumentList.arguments;
+    if (args.isEmpty) return;
+
+    final arg = args.first;
+    final type = arg.staticType;
+    if (type == null || type is DynamicType) return;
+
+    if (!type.isDartCoreMap && !type.isDartCoreList) {
+      rule.reportAtNode(arg, arguments: [type.getDisplayString()]);
+    }
   }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-/// Lint rule: `where_null_typed_value`
-///
-/// Extends [WhereNullValueRule] to also catch variables of `Null` type, not
-/// just `null` literal.
-///
-/// ```dart
-/// Null nothing;
-/// db('users').where('col', nothing); // ❌ Null-typed variable
-///
-/// // ✅ Correct
-/// db('users').whereNull('col');
-/// ```
-class WhereNullTypedValueRule extends DartLintRule {
-  WhereNullTypedValueRule() : super(code: _code);
 
-  static const LintCode _code = LintCode(
-    name: 'where_null_typed_value',
-    problemMessage:
-        'A Null-typed value was passed to .where(), producing `col = NULL` '
+class WhereNullTypedValueRule extends AnalysisRule {
+  static const LintCode code = LintCode(
+    'where_null_typed_value',
+    'A Null-typed value was passed to .where(), producing `col = NULL` '
         'which is always false in SQL.',
     correctionMessage: 'Use .whereNull(col) or .whereNotNull(col) instead.',
-    errorSeverity: DiagnosticSeverity.WARNING,
+    severity: DiagnosticSeverity.WARNING,
+    uniqueName: 'knex_dart_lint.where_null_typed_value',
   );
 
-  static const _targetMethods = {'where', 'orWhere', 'andWhere'};
+  WhereNullTypedValueRule()
+    : super(
+        name: 'where_null_typed_value',
+        description: 'Flags Null-typed values passed to .where().',
+      );
 
   @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
+  DiagnosticCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
   ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      if (!_targetMethods.contains(node.methodName.name)) return;
+    registry.addMethodInvocation(this, _WhereNullTypedVisitor(this));
+  }
+}
 
-      final args = node.argumentList.arguments;
-      if (args.isEmpty) return;
+const _whereTypedMethods = {'where', 'orWhere', 'andWhere'};
 
-      // 2-arg: where(col, nullVar) — position 1
-      // 3-arg: where(col, op, nullVar) — position 2
-      final valueIndex = args.length == 2 ? 1 : (args.length == 3 ? 2 : -1);
-      if (valueIndex < 0) return;
+class _WhereNullTypedVisitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _WhereNullTypedVisitor(this.rule);
 
-      final valueArg = args[valueIndex];
-      // Skip null literals — those are already caught by WhereNullValueRule
-      if (valueArg is NullLiteral) return;
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (!_whereTypedMethods.contains(node.methodName.name)) return;
 
-      final type = valueArg.staticType;
-      if (type == null) return;
+    final args = node.argumentList.arguments;
+    if (args.isEmpty) return;
 
-      if (type.isDartCoreNull) {
-        reporter.atNode(valueArg, _code);
-      }
-    });
+    final valueIndex = args.length == 2 ? 1 : (args.length == 3 ? 2 : -1);
+    if (valueIndex < 0) return;
+
+    final valueArg = args[valueIndex];
+    if (valueArg is NullLiteral) return;
+
+    final type = valueArg.staticType;
+    if (type == null) return;
+
+    if (type.isDartCoreNull) {
+      rule.reportAtNode(valueArg);
+    }
   }
 }

--- a/packages/knex_dart_lint/lib/src/rules/where_null_value_rule.dart
+++ b/packages/knex_dart_lint/lib/src/rules/where_null_value_rule.dart
@@ -1,60 +1,58 @@
+import 'package:analyzer/analysis_rule/analysis_rule.dart';
+import 'package:analyzer/analysis_rule/rule_context.dart';
+import 'package:analyzer/analysis_rule/rule_visitor_registry.dart';
 import 'package:analyzer/dart/ast/ast.dart';
-import 'package:analyzer/error/error.dart' show DiagnosticSeverity;
-import 'package:analyzer/error/listener.dart' show DiagnosticReporter;
-import 'package:custom_lint_builder/custom_lint_builder.dart';
+import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:analyzer/error/error.dart';
 
-/// Lint rule: `where_null_value`
-///
-/// NOTE: knex_dart's `.where(col, null)` compiler delegates to `whereNull()`
-/// and correctly produces `WHERE col IS NULL`. This rule is therefore
-/// informational only — it nudges users toward the explicit `.whereNull(col)`
-/// form for clarity, not because the implicit form is incorrect.
-///
-/// ```dart
-/// // ⚠️ Works correctly but prefer the explicit form
-/// db('users').where('deleted_at', null);
-///
-/// // ✅ Preferred — intent is clearer
-/// db('users').whereNull('deleted_at');
-/// ```
-class WhereNullValueRule extends DartLintRule {
-  WhereNullValueRule() : super(code: _code);
+const _whereNullMethods = {'where', 'orWhere', 'andWhere'};
 
-  static const LintCode _code = LintCode(
-    name: 'where_null_value',
-    problemMessage:
-        'Prefer .whereNull(col) over .where(col, null) for explicit NULL checks.',
+class WhereNullValueRule extends AnalysisRule {
+  // INFO severity (default) — registered as a lint rule requiring opt-in.
+  static const LintCode code = LintCode(
+    'where_null_value',
+    'Prefer .whereNull(col) over .where(col, null) for explicit NULL checks.',
     correctionMessage:
         'Use .whereNull(col) or .whereNotNull(col) — intent is clearer and matches SQL idiom.',
-    errorSeverity: DiagnosticSeverity.INFO,
+    uniqueName: 'knex_dart_lint.where_null_value',
   );
 
-  static const _targetMethods = {'where', 'orWhere', 'andWhere'};
+  WhereNullValueRule()
+    : super(
+        name: 'where_null_value',
+        description: 'Nudges toward .whereNull() over .where(col, null).',
+      );
 
   @override
-  void run(
-    CustomLintResolver resolver,
-    DiagnosticReporter reporter,
-    CustomLintContext context,
+  DiagnosticCode get diagnosticCode => code;
+
+  @override
+  void registerNodeProcessors(
+    RuleVisitorRegistry registry,
+    RuleContext context,
   ) {
-    context.registry.addMethodInvocation((MethodInvocation node) {
-      if (!_targetMethods.contains(node.methodName.name)) return;
-
-      final args = node.argumentList.arguments;
-      if (args.isEmpty) return;
-
-      // 2-arg form: where(col, null)
-      if (args.length == 2 && _isNullLiteral(args[1])) {
-        reporter.atNode(args[1], _code);
-        return;
-      }
-
-      // 3-arg form: where(col, '=', null)
-      if (args.length == 3 && _isNullLiteral(args[2])) {
-        reporter.atNode(args[2], _code);
-      }
-    });
+    registry.addMethodInvocation(this, _Visitor(this));
   }
+}
 
-  bool _isNullLiteral(Expression expr) => expr is NullLiteral;
+class _Visitor extends SimpleAstVisitor<void> {
+  final AnalysisRule rule;
+  _Visitor(this.rule);
+
+  @override
+  void visitMethodInvocation(MethodInvocation node) {
+    if (!_whereNullMethods.contains(node.methodName.name)) return;
+
+    final args = node.argumentList.arguments;
+    if (args.isEmpty) return;
+
+    if (args.length == 2 && args[1] is NullLiteral) {
+      rule.reportAtNode(args[1]);
+      return;
+    }
+
+    if (args.length == 3 && args[2] is NullLiteral) {
+      rule.reportAtNode(args[2]);
+    }
+  }
 }

--- a/packages/knex_dart_lint/pubspec.yaml
+++ b/packages/knex_dart_lint/pubspec.yaml
@@ -17,10 +17,10 @@ environment:
 resolution: workspace
 
 dependencies:
+  analysis_server_plugin: ^0.3.0
   analyzer: ^8.0.0
-  custom_lint_builder: ^0.8.1
   knex_dart_capabilities: ^0.3.0
 
 dev_dependencies:
-  lints: ^6.0.0
-  test: ^1.25.6
+  lints: ^6.1.0
+  test: ^1.31.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,7 +25,7 @@ workspace:
   - benchmarks
 
 dev_dependencies:
-  melos: ^7.0.0
+  melos: ^7.8.0
 
 melos:
   scripts:


### PR DESCRIPTION
## Summary

- **sqlite3 ^2.4.0 → ^3.0.0** (resolves 3.3.3) and **sqlite3_web ^0.3.0 → ^0.9.0** — replace deprecated `.dispose()` calls with `.close()` in `sqlite_client.dart`, `sqlite_client_web.dart`, and benchmark files
- **knex_dart_lint: migrate from archived `custom_lint_builder` to `analysis_server_plugin ^0.3.0`** — rewrote all 15 lint rules from `DartLintRule + run()` to `AnalysisRule + registerNodeProcessors() + _Visitor`; added `lib/main.dart` as the new plugin entry point; `LintCode` now uses positional constructor with `uniqueName: 'knex_dart_lint.<rule>'`
- **lints** `^6.0.0 → ^6.1.0` across all packages (`docs/site` bumped from `^5.0.0`)
- **test** `^1.25.6 → ^1.31.0` across all packages
- **meta** `^1.11.0 → ^1.18.0` (knex_dart core)
- **melos** `^7.0.0 → ^7.8.0` (workspace root)
- **knex_dart_postgres**: `postgres ^3.4.50 → ^3.5.12`, version `0.3.1 → 0.3.2`

## Breaking change for knex_dart_lint users

Plugin activation changes. **Before:**
```yaml
# pubspec.yaml
dev_dependencies:
  custom_lint: ^0.8.1
```
**After:**
```yaml
# analysis_options.yaml
plugins:
  knex_dart_lint: ^0.3.0
```
`// ignore:` comments change from `// ignore: rule_name` to `// ignore: knex_dart_lint/rule_name`.

## Test plan

- [x] `melos run analyze` — 14/14 packages clean
- [x] `dart test packages/knex_dart_lint/test/` — 17 tests pass
- [x] `dart test packages/knex_dart/test/` — 600+ tests pass
- [x] `dart test drivers/knex_dart_sqlite/test/` — 118 tests pass
- [ ] Server-backed driver integration tests (postgres, mysql, mssql) — covered by CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated SQLite resource cleanup to use proper connection closure methods across the SQLite driver and benchmarks.

* **Chores**
  * Upgraded dependencies across packages: `sqlite3`, `test`, `lints`, `meta`, and `postgres` driver dependencies.
  * Refactored linting infrastructure to use the standard Dart analyzer plugin framework.
  * Updated `knex_dart_postgres` to version 0.3.2 with improved transaction handling and typed exception support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->