### PR TITLE
chore(release): bump patch versions for dependency/lint-migration changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ Add the driver for your database — it pulls in `knex_dart` automatically:
 ```yaml
 dependencies:
   knex_dart_postgres: ^0.3.2   # PostgreSQL
-  # knex_dart_mysql: ^0.3.1    # MySQL
-  # knex_dart_sqlite: ^0.4.0   # SQLite
+  # knex_dart_mysql: ^0.3.2    # MySQL
+  # knex_dart_sqlite: ^0.4.1   # SQLite
   # knex_dart_duckdb: ^0.2.1   # DuckDB (OLAP / browser WASM)
 ```
 
@@ -59,7 +59,7 @@ For SQL generation only (no live connection):
 ```yaml
 dependencies:
   knex_dart: ^1.3.1
-  knex_dart_capabilities: ^0.3.0
+  knex_dart_capabilities: ^0.3.1
 ```
 
 ## Quick Start
@@ -288,7 +288,7 @@ await db.migrate.fromSqlDir('./migrations').latest();
 ```yaml
 dev_dependencies:
   custom_lint: ^0.8.1
-  knex_dart_lint: ^0.3.0
+  knex_dart_lint: ^0.3.1
 ```
 
 ```yaml

--- a/drivers/knex_dart_bigquery/CHANGELOG.md
+++ b/drivers/knex_dart_bigquery/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.2
+
+- Bumped `knex_dart` lower bound to `^1.3.0`.
+- Bumped `lints` to `^6.1.0` and `test` to `^1.31.0`.
+
 ## 0.2.1
 
 - Tighten `knex_dart` lower bound to `^1.2.1` — `QueryInterceptor`

--- a/drivers/knex_dart_bigquery/pubspec.yaml
+++ b/drivers/knex_dart_bigquery/pubspec.yaml
@@ -1,6 +1,6 @@
 name: knex_dart_bigquery
 description: Google BigQuery driver for knex_dart — execute queries against Google BigQuery via the BigQuery REST API using the knex_dart query builder.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/kartikey321/knex-dart
 homepage: https://github.com/kartikey321/knex-dart
 issue_tracker: https://github.com/kartikey321/knex-dart/issues

--- a/drivers/knex_dart_d1/CHANGELOG.md
+++ b/drivers/knex_dart_d1/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.2
+
+- Bumped `knex_dart` lower bound to `^1.3.0`.
+- Bumped `lints` to `^6.1.0` and `test` to `^1.31.0`.
+
 ## 0.2.1
 
 - Tighten `knex_dart` lower bound to `^1.2.1` — `QueryInterceptor`

--- a/drivers/knex_dart_d1/pubspec.yaml
+++ b/drivers/knex_dart_d1/pubspec.yaml
@@ -1,6 +1,6 @@
 name: knex_dart_d1
 description: Cloudflare D1 driver for knex_dart — execute queries against a Cloudflare D1 SQLite database via the Cloudflare REST API using the knex_dart query builder.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/kartikey321/knex-dart
 homepage: https://github.com/kartikey321/knex-dart
 issue_tracker: https://github.com/kartikey321/knex-dart/issues

--- a/drivers/knex_dart_mysql/CHANGELOG.md
+++ b/drivers/knex_dart_mysql/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.2
+
+- Bumped `knex_dart` lower bound to `^1.3.0`.
+- Bumped `lints` to `^6.1.0` and `test` to `^1.31.0`.
+
 ## 0.3.1
 
 - Tighten `knex_dart` lower bound to `^1.2.1` — `QueryInterceptor`

--- a/drivers/knex_dart_mysql/pubspec.yaml
+++ b/drivers/knex_dart_mysql/pubspec.yaml
@@ -1,6 +1,6 @@
 name: knex_dart_mysql
 description: MySQL driver for knex_dart — connect and execute queries against a MySQL database using the knex_dart query builder.
-version: 0.3.1
+version: 0.3.2
 repository: https://github.com/kartikey321/knex-dart
 homepage: https://github.com/kartikey321/knex-dart
 issue_tracker: https://github.com/kartikey321/knex-dart/issues

--- a/drivers/knex_dart_snowflake/CHANGELOG.md
+++ b/drivers/knex_dart_snowflake/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.2
+
+- Bumped `knex_dart` lower bound to `^1.3.0`.
+- Bumped `lints` to `^6.1.0` and `test` to `^1.31.0`.
+
 ## 0.2.1
 
 - Tighten `knex_dart` lower bound to `^1.2.1` — `QueryInterceptor`

--- a/drivers/knex_dart_snowflake/pubspec.yaml
+++ b/drivers/knex_dart_snowflake/pubspec.yaml
@@ -1,6 +1,6 @@
 name: knex_dart_snowflake
 description: Snowflake driver for knex_dart — execute queries against Snowflake via the Snowflake SQL API v2 using the knex_dart query builder.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/kartikey321/knex-dart
 homepage: https://github.com/kartikey321/knex-dart
 issue_tracker: https://github.com/kartikey321/knex-dart/issues

--- a/drivers/knex_dart_sqlite/CHANGELOG.md
+++ b/drivers/knex_dart_sqlite/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.4.1
+
+- Bumped `sqlite3` to `^3.0.0` and `sqlite3_web` to `^0.9.0`; replaced
+  deprecated `.dispose()` calls with `.close()` in the native and web
+  clients.
+- Bumped `lints` to `^6.1.0` and `test` to `^1.31.0`.
+
 ## 0.4.0
 
 - Added `watch()` reactive query streams for SQLite based on `UPDATE_HOOK`.

--- a/drivers/knex_dart_sqlite/pubspec.yaml
+++ b/drivers/knex_dart_sqlite/pubspec.yaml
@@ -1,6 +1,6 @@
 name: knex_dart_sqlite
 description: SQLite driver for knex_dart — connect and execute queries against a SQLite database using the knex_dart query builder.
-version: 0.4.0
+version: 0.4.1
 repository: https://github.com/kartikey321/knex-dart
 homepage: https://github.com/kartikey321/knex-dart
 issue_tracker: https://github.com/kartikey321/knex-dart/issues

--- a/drivers/knex_dart_turso/CHANGELOG.md
+++ b/drivers/knex_dart_turso/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.2
+
+- Bumped `knex_dart` lower bound to `^1.3.0`.
+- Bumped `lints` to `^6.1.0` and `test` to `^1.31.0`.
+
 ## 0.2.1
 
 - Tighten `knex_dart` lower bound to `^1.2.1` — `QueryInterceptor`

--- a/drivers/knex_dart_turso/pubspec.yaml
+++ b/drivers/knex_dart_turso/pubspec.yaml
@@ -1,6 +1,6 @@
 name: knex_dart_turso
 description: Turso (libSQL) driver for knex_dart — connect and execute queries against a Turso database over the libSQL HTTP API using the knex_dart query builder.
-version: 0.2.1
+version: 0.2.2
 repository: https://github.com/kartikey321/knex-dart
 homepage: https://github.com/kartikey321/knex-dart
 issue_tracker: https://github.com/kartikey321/knex-dart/issues

--- a/packages/knex_dart/README.md
+++ b/packages/knex_dart/README.md
@@ -49,8 +49,8 @@ Add the driver for your database — it pulls in `knex_dart` automatically:
 ```yaml
 dependencies:
   knex_dart_postgres: ^0.3.2   # PostgreSQL
-  # knex_dart_mysql: ^0.3.1    # MySQL
-  # knex_dart_sqlite: ^0.4.0   # SQLite
+  # knex_dart_mysql: ^0.3.2    # MySQL
+  # knex_dart_sqlite: ^0.4.1   # SQLite
   # knex_dart_duckdb: ^0.2.1   # DuckDB (OLAP / browser WASM)
 ```
 
@@ -59,7 +59,7 @@ For SQL generation only (no live connection):
 ```yaml
 dependencies:
   knex_dart: ^1.3.1
-  knex_dart_capabilities: ^0.3.0
+  knex_dart_capabilities: ^0.3.1
 ```
 
 ## Quick Start
@@ -367,7 +367,7 @@ await db.migrate.fromSqlDir('./migrations').latest();
 ```yaml
 dev_dependencies:
   custom_lint: ^0.8.1
-  knex_dart_lint: ^0.3.0
+  knex_dart_lint: ^0.3.1
 ```
 
 ```yaml

--- a/packages/knex_dart_capabilities/CHANGELOG.md
+++ b/packages/knex_dart_capabilities/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+- Bumped `lints` to `^6.1.0` and `test` to `^1.31.0` (no source changes).
+
 ## 0.3.0
 
 - Added `KnexDialect.mssql` to the dialect enum and populated its capability

--- a/packages/knex_dart_capabilities/pubspec.yaml
+++ b/packages/knex_dart_capabilities/pubspec.yaml
@@ -1,6 +1,6 @@
 name: knex_dart_capabilities
 description: Shared dialect capability matrix for knex_dart runtime and tooling.
-version: 0.3.0
+version: 0.3.1
 repository: https://github.com/kartikey321/knex-dart
 homepage: https://github.com/kartikey321/knex-dart
 issue_tracker: https://github.com/kartikey321/knex-dart/issues

--- a/packages/knex_dart_lint/CHANGELOG.md
+++ b/packages/knex_dart_lint/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.1
+
+- Migrated the plugin from the archived `custom_lint_builder` to
+  `analysis_server_plugin ^0.3.0`: all 15 rules moved from
+  `DartLintRule` + `run()` to `AnalysisRule` + `registerNodeProcessors()` +
+  a `_Visitor` pattern, and a `lib/main.dart` plugin entry point was added.
+- Bumped `lints` to `^6.1.0` and `test` to `^1.31.0`.
+
 ## 0.3.0
 
 - Added `raw_null_identifier_binding` lint rule (WARNING): fires when a `:key:`

--- a/packages/knex_dart_lint/README.md
+++ b/packages/knex_dart_lint/README.md
@@ -1,6 +1,6 @@
 # knex_dart_lint
 
-Optional `custom_lint` plugin for `knex_dart`.
+Optional analyzer plugin for `knex_dart`, built on `analysis_server_plugin`.
 
 This package provides dialect-aware warnings for query APIs that are unsupported
 for the inferred driver.
@@ -29,27 +29,42 @@ for the inferred driver.
 
 ## Enable
 
-Add to your app/package `pubspec.yaml`:
+Add a top-level `plugins` section to the `analysis_options.yaml` at the root
+of your package or [workspace](https://dart.dev/tools/pub/workspaces) (plugins
+cannot be enabled from a nested analysis options file):
 
 ```yaml
-dev_dependencies:
-  custom_lint: ^0.7.0
+plugins:
+  knex_dart_lint: ^0.3.0
+```
+
+While developing against a local checkout, use a path instead:
+
+```yaml
+plugins:
   knex_dart_lint:
     path: ../packages/knex_dart_lint
 ```
 
-Then update `analysis_options.yaml`:
+No separate dev dependency or CLI runner is needed — `knex_dart_lint` is a
+native analyzer plugin, so its diagnostics show up directly from `dart
+analyze` / `flutter analyze` and in the IDE, the same as built-in lints.
+
+Restart the Dart Analysis Server (or your IDE) after changing the `plugins`
+section for the change to take effect.
+
+## Enabling an opt-in rule
+
+Warning-severity rules are on by default. Opt-in lint rules — currently just
+`where_null_value` — are disabled by default and must be enabled under
+`diagnostics`:
 
 ```yaml
-analyzer:
-  plugins:
-    - custom_lint
-```
-
-## Run
-
-```bash
-dart run custom_lint
+plugins:
+  knex_dart_lint:
+    version: ^0.3.0
+    diagnostics:
+      where_null_value: true
 ```
 
 ## Confidence behavior
@@ -57,13 +72,22 @@ dart run custom_lint
 Dialect capability rules emit diagnostics only when dialect inference is high-confidence.
 If inference is unknown, those rules intentionally stay silent.
 
+## Suppressing a diagnostic
+
+```dart
+// ignore: knex_dart_lint/dialect_unsupported_returning
+
+// ignore_for_file: knex_dart_lint/dialect_unsupported_returning
+```
+
 ## Troubleshooting
 
-If CLI works but IDE does not show diagnostics:
+If diagnostics don't show up:
 
-1. Confirm `analysis_options.yaml` includes `analyzer.plugins: [custom_lint]`.
+1. Confirm `analysis_options.yaml` has a top-level `plugins:` section (not
+   nested under `analyzer:` — that was the old `custom_lint` layout).
 2. Run `dart pub get` in the workspace and the consuming app.
-3. Ensure the IDE can resolve `dart` from its environment `PATH`.
-4. Open the `custom_lint.log` from the IDE and check for process spawn errors.
+3. Restart the Dart Analysis Server / restart the IDE.
+4. Ensure the IDE can resolve `dart` from its environment `PATH`.
 
 See `docs/mvp_rules.md` for the locked rule contract.

--- a/packages/knex_dart_lint/pubspec.yaml
+++ b/packages/knex_dart_lint/pubspec.yaml
@@ -1,13 +1,13 @@
 name: knex_dart_lint
-description: Optional custom_lint plugin for dialect-aware Knex Dart capability checks.
-version: 0.3.0
+description: Optional analyzer plugin for dialect-aware Knex Dart capability checks.
+version: 0.3.1
 repository: https://github.com/kartikey321/knex-dart
 homepage: https://github.com/kartikey321/knex-dart
 issue_tracker: https://github.com/kartikey321/knex-dart/issues
 topics:
   - sql
   - lint
-  - custom-lint
+  - analyzer-plugin
   - query-builder
   - knex
 


### PR DESCRIPTION
## Summary
- Bumps `knex_dart_capabilities`, `knex_dart_lint`, `knex_dart_mysql`, `knex_dart_sqlite`, `knex_dart_turso`, `knex_dart_d1`, `knex_dart_snowflake`, `knex_dart_bigquery` — each had lib/pubspec-relevant commits (dependency bumps, and for `knex_dart_lint` the migration off the archived `custom_lint_builder` to `analysis_server_plugin`) land without a version bump.
- `knex_dart_duckdb` is intentionally left out — its driver has its own upcoming changes and will get a combined bump later.
- Updates `knex_dart_lint`'s README to document the `analysis_server_plugin` setup flow (top-level `plugins:` section, no `custom_lint` dev dependency or CLI runner) in place of the stale `custom_lint` instructions.

## Test plan
- [ ] `melos run analyze` passes across the workspace
- [ ] `make test-unit` passes
- [ ] Tag and publish each bumped package once merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Releases**
  - Published updated versions of the BigQuery, D1, MySQL, Snowflake, SQLite, Turso, capabilities, and lint packages.
  - Improved SQLite client compatibility by replacing deprecated disposal behavior with the supported close operation.

- **Improvements**
  - Migrated the lint plugin to the Dart analyzer plugin system.
  - Updated setup and troubleshooting guidance, including configuration through `analysis_options.yaml` and IDE-based diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->