### PR TITLE
fix(sqlite-web): release OPFS/IndexedDB handles on client close

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,34 +202,25 @@ jobs:
           sed -i.bak "/knex_dart_duckdb/d" pubspec.yaml
           dart pub get
 
-      # SQLite WASM — sqlite3 package exposes package:sqlite3/wasm.dart
-      # dart test serves package assets from lib/ under relative packages/<pkg>/...
+      # SQLite WASM — sqlite3 package exposes package:sqlite3/wasm.dart.
+      # `dart test --platform=chrome` serves this package's own files (test/
+      # and lib/) under a per-run URL, not a stable /packages/<pkg>/... route
+      # — see WorkerHarness.packageRootUrl in test/browser/worker_harness.dart
+      # for how tests resolve lib/web_assets/* at runtime.
       - name: Download SQLite WASM asset
         working-directory: drivers/knex_dart_sqlite
-        run: |
-          SQLITE3_VERSION="$(ruby -rjson -e '
-            cfg = JSON.parse(File.read("../../.dart_tool/package_config.json"))
-            pkg = cfg["packages"].find { |p| p["name"] == "sqlite3" }
-            abort("sqlite3 package not found in package_config") unless pkg
-            root = pkg["rootUri"]
-            root = root.sub(%r{\Afile://}, "") if root.start_with?("file://")
-            root = File.expand_path(root, "../../.dart_tool") unless root.start_with?("/")
-            version = File.basename(root)[/^sqlite3-(.+)$/, 1]
-            abort("Could not infer sqlite3 version from #{root}") unless version
-            puts version
-          ')"
+        run: dart run tool/download_wasm.dart
 
-          URL_TAGGED="https://github.com/simolus3/sqlite3.dart/releases/download/sqlite3-${SQLITE3_VERSION}/sqlite3.wasm"
-          URL_LATEST="https://github.com/simolus3/sqlite3.dart/releases/latest/download/sqlite3.wasm"
-          URL_VERSIONED_V="https://github.com/simolus3/sqlite3.dart/releases/download/v${SQLITE3_VERSION}/sqlite3.wasm"
-          URL_VERSIONED_RAW="https://github.com/simolus3/sqlite3.dart/releases/download/${SQLITE3_VERSION}/sqlite3.wasm"
-
-          mkdir -p lib/web_assets
-          curl -fL "$URL_TAGGED" -o lib/web_assets/sqlite3.wasm \
-            || curl -fL "$URL_LATEST" -o lib/web_assets/sqlite3.wasm \
-            || curl -fL "$URL_VERSIONED_V" -o lib/web_assets/sqlite3.wasm \
-            || curl -fL "$URL_VERSIONED_RAW" -o lib/web_assets/sqlite3.wasm
-          ls -lh lib/web_assets/sqlite3.wasm
+      # test/browser/opfs_indexeddb_close_test.dart spawns a real dedicated
+      # Worker running test/browser/opfs_worker.dart (SimpleOpfsFileSystem —
+      # package:sqlite3's OPFS VFS — only works inside a dedicated worker,
+      # never on a tab's main thread). `dart test` only compiles the
+      # *_test.dart entrypoints it runs, so this second, worker-only
+      # entrypoint has to be compiled separately, same idea as vendoring the
+      # DuckDB WASM binary above.
+      - name: Compile OPFS/IndexedDB browser-test worker
+        working-directory: drivers/knex_dart_sqlite
+        run: dart run tool/build_browser_worker.dart
 
       - name: Run SQLite WASM tests (Chrome)
         working-directory: drivers/knex_dart_sqlite

--- a/drivers/knex_dart_sqlite/.gitignore
+++ b/drivers/knex_dart_sqlite/.gitignore
@@ -1,12 +1,4 @@
-# Dart / Flutter tool state
-.dart_tool/
-
-# Build outputs
-build/
-
-# Library packages should not commit lockfiles.
-pubspec.lock
-
-# Flutter tool artifacts (if present)
-.flutter-plugins
-.flutter-plugins-dependencies
+# Downloaded sqlite3 WASM binary and the compiled OPFS/IndexedDB browser-test
+# worker — regenerated via: dart run tool/download_wasm.dart
+#                           dart run tool/build_browser_worker.dart
+lib/web_assets/

--- a/drivers/knex_dart_sqlite/dart_test.yaml
+++ b/drivers/knex_dart_sqlite/dart_test.yaml
@@ -1,0 +1,38 @@
+# Chrome settings for `dart test --platform=chrome` (used both by the
+# existing WASM tests and by the OPFS/IndexedDB worker tests under
+# test/browser/ — see test/browser/opfs_indexeddb_close_test.dart).
+#
+# No `custom_html_template_path` here: unlike drivers/knex_dart_duckdb (which
+# needs one to inject CDN <script type="module"> glue for duckdb-wasm), this
+# package's WASM loading happens entirely in Dart via
+# `WasmSqlite3.loadFromUrl`, and both sqlite3.wasm and the compiled worker
+# script are already reachable from the default test page through its own
+# location (see WorkerHarness.packageRootUrl in test/browser/worker_harness.dart)
+# — a custom template would apply package-wide for no benefit here and would
+# risk the already-green default WASM tests.
+on_platform:
+  chrome:
+    timeout: 5m
+    # NOT used to paper over flakiness in test/browser/'s race-condition
+    # tests specifically — those were separately verified to pass
+    # deterministically on the first try (repeated runs with retry: 0 and
+    # -j 1); this only covers this driver's other Chrome suites (WASM
+    # loading, sqlite_trx_test.dart et al., mirroring duckdb's dart_test.yaml
+    # precedent for occasional browser-launch flakiness in CI).
+    retry: 2
+    settings:
+      headless: true
+      arguments: >-
+        --no-sandbox
+        --disable-gpu
+        --headless=new
+        --disable-dev-shm-usage
+        --disable-software-rasterizer
+        --no-first-run
+        --mute-audio
+        --disable-extensions
+        --disable-background-timer-throttling
+        --disable-backgrounding-occluded-windows
+        --disable-popup-blocking
+        --disable-notifications
+        --disable-translate

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client.dart
@@ -273,7 +273,23 @@ class SQLiteClient extends Client {
         }
         return result;
       } catch (e) {
-        _db.execute('ROLLBACK');
+        try {
+          _db.execute('ROLLBACK');
+        } catch (_) {
+          // ROLLBACK can itself fail — e.g. the callback already ended the
+          // transaction via raw SQL ("cannot rollback - no transaction is
+          // active"), or the connection was closed concurrently. Swallow so
+          // the cleanup below still runs and the *original* error (not this
+          // one) is what propagates — mirrors the SAVEPOINT branch above,
+          // which already guards its ROLLBACK TO SAVEPOINT the same way.
+          // Before this guard existed, a failing ROLLBACK here would skip
+          // _txUpdateStack.removeLast() below, permanently leaving a stale
+          // entry on the stack — which made watch() silently stop emitting
+          // for non-transactional writes for the rest of this client's
+          // lifetime, because the update hook checks
+          // `_txUpdateStack.isNotEmpty` to decide whether to buffer instead
+          // of forwarding straight to _updateController.
+        }
         _txUpdateStack.removeLast(); // discard all uncommitted updates
         rethrow;
       } finally {

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
@@ -15,6 +15,17 @@ class SQLiteClient extends Client {
   final SQLiteWebStorageMode _storageMode;
   bool _isClosed = false;
 
+  /// The virtual file system created for this client during
+  /// [_initializeImpl], kept so it can be released in [destroyPool].
+  ///
+  /// [SimpleOpfsFileSystem] holds open `FileSystemSyncAccessHandle`s and
+  /// [IndexedDbFileSystem] holds an open `IDBDatabase` connection; both must
+  /// be explicitly closed or they outlive this client (browsers do not
+  /// promptly release either just because the Dart object is unreferenced),
+  /// which then blocks any later attempt to delete/replace the underlying
+  /// storage (OPFS `removeEntry` / `indexedDB.deleteDatabase`).
+  VirtualFileSystem? _fileSystem;
+
   /// Depth counter for nested transactions (0 = no active transaction).
   int _transactionDepth = 0;
 
@@ -26,7 +37,8 @@ class SQLiteClient extends Client {
 
   Future<void>? _initialization;
   final List<List<SqliteUpdate>> _txUpdateStack = [];
-  late final StreamController<SqliteUpdate> _updateController;
+  final StreamController<SqliteUpdate> _updateController =
+      StreamController<SqliteUpdate>.broadcast(sync: true);
   StreamSubscription<SqliteUpdate>? _updatesSub;
 
   SQLiteClient._(
@@ -128,19 +140,50 @@ class SQLiteClient extends Client {
   Future<void> _initializeImpl() async {
     final sqlite = await _loadSqlite3();
     final fileSystem = await _createFileSystem();
+    // Store the reference immediately so it can be released even if a step
+    // below (registration, open) throws, or if the client is closed before
+    // initialization finishes.
+    _fileSystem = fileSystem;
     sqlite.registerVirtualFileSystem(fileSystem, makeDefault: true);
 
     final opened = sqlite.open(_filename);
     if (_isClosed) {
       opened.close();
+      await _closeFileSystem();
       return;
     }
     _db = opened;
     _setupUpdateHook(opened);
   }
 
+  /// Releases the resources held by [_fileSystem], if any.
+  ///
+  /// [SimpleOpfsFileSystem] and [IndexedDbFileSystem] each hold a real,
+  /// exclusive browser-level resource (OPFS sync access handles / an
+  /// `IDBDatabase` connection) that is not released just because this Dart
+  /// object becomes unreferenced — it must be closed explicitly, or it
+  /// blocks later attempts to delete/replace the same storage.
+  /// [InMemoryFileSystem] holds nothing external and needs no cleanup.
+  ///
+  /// This must never throw: it always runs from a `finally` block, and an
+  /// exception here must not mask the original error or skip the rest of
+  /// that cleanup.
+  Future<void> _closeFileSystem() async {
+    final fs = _fileSystem;
+    _fileSystem = null;
+    if (fs == null) return;
+    try {
+      if (fs is SimpleOpfsFileSystem) {
+        fs.close();
+      } else if (fs is IndexedDbFileSystem) {
+        await fs.close();
+      }
+    } catch (_) {
+      // Best-effort cleanup; swallow so callers' finally blocks still run.
+    }
+  }
+
   void _setupUpdateHook(CommonDatabase db) {
-    _updateController = StreamController<SqliteUpdate>.broadcast(sync: true);
     _updatesSub = db.updates.listen((update) {
       if (_updateController.isClosed) return;
       if (_txUpdateStack.isNotEmpty) {
@@ -227,9 +270,13 @@ class SQLiteClient extends Client {
       await initialize();
     } finally {
       await _updatesSub?.cancel();
+      // Close the sqlite3 database (and thus each open file's `xClose()`)
+      // before releasing the VFS-level resources below — OPFS/IndexedDB
+      // handles must stay valid until sqlite3 is done flushing them.
       _db?.close();
       _db = null;
       _isClosed = true;
+      await _closeFileSystem();
       if (!_updateController.isClosed) {
         await _updateController.close();
       }

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
@@ -144,16 +144,26 @@ class SQLiteClient extends Client {
     // below (registration, open) throws, or if the client is closed before
     // initialization finishes.
     _fileSystem = fileSystem;
-    sqlite.registerVirtualFileSystem(fileSystem, makeDefault: true);
 
-    final opened = sqlite.open(_filename);
-    if (_isClosed) {
-      opened.close();
+    // If registration or open() throws, this Future rejects and connect()
+    // never returns a client — so no caller can ever reach close() to
+    // release fileSystem. Release it here instead, on the way out.
+    CommonDatabase? opened;
+    try {
+      sqlite.registerVirtualFileSystem(fileSystem, makeDefault: true);
+      opened = sqlite.open(_filename);
+      if (_isClosed) {
+        opened.close();
+        await _closeFileSystem();
+        return;
+      }
+      _db = opened;
+      _setupUpdateHook(opened);
+    } catch (_) {
+      opened?.close();
       await _closeFileSystem();
-      return;
+      rethrow;
     }
-    _db = opened;
-    _setupUpdateHook(opened);
   }
 
   /// Releases the resources held by [_fileSystem], if any.

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
@@ -241,6 +241,13 @@ class SQLiteClient extends Client {
   Future<CommonDatabase> _ensureDb() async {
     if (_isClosed) throw StateError('SQLiteClient is closed');
     await initialize();
+    // Re-check: close() may have run while the await above was pending and
+    // won the race against a still-in-flight _initializeImpl() (which then
+    // takes its early-return branch and leaves _db null without throwing) —
+    // that's "closed concurrently", not "failed to initialize", and deserves
+    // the accurate error rather than the misleading wasm-loading message
+    // below.
+    if (_isClosed) throw StateError('SQLiteClient is closed');
     final db = _db;
     if (db == null) {
       throw StateError(
@@ -278,6 +285,13 @@ class SQLiteClient extends Client {
     if (_isClosed) return;
     try {
       await initialize();
+    } catch (_) {
+      // initialize() may have failed (e.g. VFS registration or sqlite.open()
+      // threw) — that failure already propagated once to whoever originally
+      // awaited initialize()/connect(); close() is cleanup, not a second
+      // place to report it, and must still release whatever
+      // _initializeImpl() managed to create (_fileSystem) before it failed
+      // — which the finally block below does regardless of this catch.
     } finally {
       await _updatesSub?.cancel();
       // Close the sqlite3 database (and thus each open file's `xClose()`)

--- a/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
+++ b/drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart
@@ -402,7 +402,16 @@ class SQLiteClient extends Client {
         }
         return result;
       } catch (e) {
-        db.execute('ROLLBACK');
+        try {
+          db.execute('ROLLBACK');
+        } catch (_) {
+          // See sqlite_client.dart's equivalent guard (native client): a
+          // failing ROLLBACK here (already-ended transaction, concurrent
+          // close) must not skip the update-hook stack cleanup below or mask
+          // the original error with the rollback's own — mirrors the
+          // SAVEPOINT branch above, which already guards its ROLLBACK TO
+          // SAVEPOINT the same way.
+        }
         await _settleUpdateHookQueue();
         _txUpdateStack.removeLast();
         rethrow;

--- a/drivers/knex_dart_sqlite/pubspec.yaml
+++ b/drivers/knex_dart_sqlite/pubspec.yaml
@@ -26,3 +26,4 @@ dependencies:
 dev_dependencies:
   test: ^1.31.0
   lints: ^6.1.0
+  web: ^1.1.0

--- a/drivers/knex_dart_sqlite/test/browser/indexeddb_main_thread_test.dart
+++ b/drivers/knex_dart_sqlite/test/browser/indexeddb_main_thread_test.dart
@@ -1,0 +1,69 @@
+/// Confirms `IndexedDbFileSystem` (and `InMemoryFileSystem`) have no
+/// dedicated-worker requirement — unlike `SimpleOpfsFileSystem`, whose class
+/// doc comment in sqlite3's `lib/src/wasm/vfs/simple_opfs.dart` explicitly
+/// restricts it to dedicated workers ("not in the JavaScript context for a
+/// tab or a shared web worker"). This runs `SQLiteClient` with `storageMode:
+/// 'indexedDb'` directly on the test page's main thread — no
+/// WorkerHarness/opfs_worker.dart anywhere in this file — as direct
+/// confirmation rather than trusting sqlite3's docs at face value.
+@TestOn('browser')
+library;
+
+import 'package:knex_dart/knex_dart.dart';
+import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
+import 'package:sqlite3/wasm.dart' show IndexedDbFileSystem;
+import 'package:test/test.dart';
+
+import 'worker_harness.dart' show WorkerHarness;
+
+String _wasmUri() {
+  // Same "walk this page's own URL back to package root" trick as
+  // WorkerHarness.packageRootUrl — reused directly since this file lives at
+  // the same test/browser/ depth and the main thread's `window.location` is
+  // the exact same kind of per-run hash-prefixed URL a worker's would be.
+  return '${WorkerHarness.packageRootUrl()}lib/web_assets/sqlite3.wasm';
+}
+
+SQLiteClient _indexedDbClient(String filename) {
+  return SQLiteClient.fromConfig(
+    KnexConfig(
+      client: 'sqlite3',
+      connection: {
+        'filename': filename,
+        'storageMode': 'indexedDb',
+        'wasmUri': _wasmUri(),
+      },
+    ),
+  );
+}
+
+void main() {
+  test(
+    'indexedDb storage mode: write, close, reopen succeeds without a '
+    'dedicated worker',
+    () async {
+      final filename =
+          'knex-sqlite-mainthread-indexeddb-'
+          '${DateTime.now().microsecondsSinceEpoch}';
+
+      final client = _indexedDbClient(filename);
+      await client.initialize();
+      await client.rawQuery('CREATE TABLE t (id INTEGER)', const []);
+      await client.rawQuery('INSERT INTO t (id) VALUES (1)', const []);
+      await client.close();
+
+      // No dedicated worker anywhere in this test — if IndexedDbFileSystem
+      // actually required one (like SimpleOpfsFileSystem does), opening it
+      // above would already have failed with a VFS-registration or "not
+      // available in this context" style error.
+      final verify = _indexedDbClient(filename);
+      await verify.initialize();
+      final rows = await verify.rawQuery('SELECT * FROM t', const []);
+      await verify.close();
+
+      expect(rows, hasLength(1));
+
+      await IndexedDbFileSystem.deleteDatabase(filename);
+    },
+  );
+}

--- a/drivers/knex_dart_sqlite/test/browser/opfs_indexeddb_close_test.dart
+++ b/drivers/knex_dart_sqlite/test/browser/opfs_indexeddb_close_test.dart
@@ -1,0 +1,207 @@
+/// Browser tests for the OPFS/IndexedDB handle-leak fix in
+/// `SQLiteClient` (web) — drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart.
+///
+/// These run the actual `SQLiteClient` (fromConfig — the same code path
+/// `SQLiteClient.connect()` / `KnexSQLite.connect()` use internally) inside a
+/// real dedicated Web Worker, because `SimpleOpfsFileSystem` (package:sqlite3's
+/// OPFS VFS) only works inside a dedicated worker, never on the main thread of
+/// a tab (see sqlite3's `lib/src/wasm/vfs/simple_opfs.dart` class doc
+/// comment). See worker_harness.dart / opfs_worker.dart for the RPC protocol
+/// this test drives.
+///
+/// Before running (see tool/):
+///   dart run tool/download_wasm.dart
+///   dart run tool/build_browser_worker.dart
+///   dart test test/browser/ --platform=chrome
+///
+/// `SQLiteClient` and `KnexSQLite` are not tested separately here:
+/// `KnexSQLite.close()` (lib/src/knex_sqlite.dart) is a pure passthrough to
+/// `SQLiteClient.close()` with no additional logic of its own, and every race
+/// this suite probes (double close, close during init, close during a query)
+/// lives entirely inside `SQLiteClient`'s internals
+/// (`destroyPool`/`_closeFileSystem`/`_initializeImpl`). Testing the wrapper
+/// on top would assert the exact same thing through an extra layer of
+/// indirection.
+@TestOn('browser')
+library;
+
+import 'package:test/test.dart';
+
+import 'worker_harness.dart';
+
+/// Storage-mode-specific bug-repro + cleanup actions, parameterizing the
+/// shared scenario bodies below over 'opfs' and 'indexedDb'.
+class _StorageMode {
+  final String name;
+  final String writeCloseDeleteAction;
+  final String deleteAction;
+
+  const _StorageMode({
+    required this.name,
+    required this.writeCloseDeleteAction,
+    required this.deleteAction,
+  });
+
+  static const opfs = _StorageMode(
+    name: 'opfs',
+    writeCloseDeleteAction: 'opfsWriteCloseDelete',
+    deleteAction: 'deleteOpfsStorage',
+  );
+
+  static const indexedDb = _StorageMode(
+    name: 'indexedDb',
+    writeCloseDeleteAction: 'indexedDbWriteCloseDelete',
+    deleteAction: 'deleteIndexedDb',
+  );
+}
+
+int _fileCounter = 0;
+
+/// A filename unique to this test run/scenario. OPFS and IndexedDB storage
+/// is per-origin and outlives a single test (same localhost:port for the
+/// whole `dart test` run), so reusing a name across tests would make close()
+/// timing bugs order-dependent instead of deterministic.
+String _uniqueFilename(String tag) =>
+    'knex-sqlite-$tag-${DateTime.now().microsecondsSinceEpoch}-${_fileCounter++}';
+
+void main() {
+  test('sanity: dedicated worker spawns and responds', () async {
+    final harness = WorkerHarness.spawn();
+    addTearDown(harness.dispose);
+
+    expect(await harness.callOk('ping'), 'pong');
+    // A stray uncaught error from the worker can arrive a microtask after
+    // the reply that answered this call — pump before asserting the list is
+    // empty, everywhere in this file, so that assertion is actually load-
+    // bearing instead of racing the very thing it's checking for.
+    await pumpEventQueue();
+    expect(harness.uncaughtWorkerErrors, isEmpty);
+  });
+
+  for (final mode in [_StorageMode.opfs, _StorageMode.indexedDb]) {
+    group(mode.name, () {
+      late WorkerHarness harness;
+      late String filename;
+
+      setUp(() {
+        harness = WorkerHarness.spawn();
+        filename = _uniqueFilename(mode.name);
+      });
+
+      tearDown(() async {
+        // Best-effort: if a test leaves storage in a state the worker can't
+        // clean up itself (e.g. it crashed), don't let that mask the actual
+        // assertion failure or leak into later tests.
+        try {
+          await harness.call(mode.deleteAction, {'filename': filename});
+        } on Object {
+          // ignored — some scenarios already delete as part of the test.
+        }
+        await harness.dispose();
+      });
+
+      test(
+        'write -> close -> delete succeeds (issue #18 repro, fixed)',
+        () async {
+          final result = await harness.callOk(mode.writeCloseDeleteAction, {
+            'filename': filename,
+          });
+          expect(result, {'deleted': true});
+          await pumpEventQueue();
+          expect(harness.uncaughtWorkerErrors, isEmpty);
+        },
+      );
+
+      test(
+        'two concurrent close() calls: no throw, no double-release, '
+        'storage still deletable after',
+        () async {
+          final result =
+              await harness.callOk('doubleClose', {
+                    'filename': filename,
+                    'storageMode': mode.name,
+                  })
+                  as Map<String, dynamic>;
+          expect(
+            result['isClosed'],
+            isTrue,
+            reason: 'client must report closed after Future.wait([close(), '
+                'close()])',
+          );
+          await pumpEventQueue();
+          expect(
+            harness.uncaughtWorkerErrors,
+            isEmpty,
+            reason: 'neither close() call may raise or leak an uncaught '
+                'error',
+          );
+
+          // The real point of the test: storage must not be left locked by
+          // a handle that only one of the two close() calls released.
+          await harness.callOk(mode.deleteAction, {'filename': filename});
+        },
+      );
+
+      test(
+        'close() called before initialize() is ever awaited (pending-init '
+        'window): no uncaught error, storage still deletable after',
+        () async {
+          final result =
+              await harness.callOk('closeDuringInit', {
+                    'filename': filename,
+                    'storageMode': mode.name,
+                  })
+                  as Map<String, dynamic>;
+          expect(result['isClosed'], isTrue);
+          // Both futures are awaited with their own try/catch inside the
+          // worker (see opfs_worker.dart._closeDuringInit) specifically so a
+          // thrown error here surfaces as a *value* (initError/closeError)
+          // instead of an uncaught worker-side exception. Neither should
+          // actually be set: initialize() should complete successfully
+          // (destroyPool()'s `await initialize()` shares the same pending
+          // future, so close() waits for init to finish rather than
+          // interrupting it — see PR description for the full trace) and
+          // close() should complete cleanly afterwards.
+          expect(result['initError'], isNull, reason: result.toString());
+          expect(result['closeError'], isNull, reason: result.toString());
+          await pumpEventQueue();
+          expect(harness.uncaughtWorkerErrors, isEmpty);
+
+          await harness.callOk(mode.deleteAction, {'filename': filename});
+        },
+      );
+
+      test(
+        'close() called while a write query is in flight: no corruption, '
+        'no uncaught error',
+        () async {
+          final result =
+              await harness.callOk('closeDuringQuery', {
+                    'filename': filename,
+                    'storageMode': mode.name,
+                  })
+                  as Map<String, dynamic>;
+          expect(result['isClosed'], isTrue);
+          // Acceptable outcomes per the task's own bar: either the in-flight
+          // query completes before teardown reaches it (queryError is null —
+          // this is what's actually observed: _ensureDb's `await
+          // initialize()` and destroyPool's `await initialize()` both
+          // resolve off the same already-completed future, and since the
+          // query's await was scheduled first, Dart's FIFO microtask queue
+          // runs its continuation — which finishes the fully-synchronous
+          // prepare/execute — before destroyPool's finally block ever runs),
+          // or it's cut off with a clean StateError. What's never acceptable
+          // is a hang (the harness's per-call timeout would have already
+          // failed the test above) or an uncaught error (asserted below).
+          if (result['queryError'] != null) {
+            expect(result['queryError'], contains('StateError'));
+          }
+          await pumpEventQueue();
+          expect(harness.uncaughtWorkerErrors, isEmpty);
+
+          await harness.callOk(mode.deleteAction, {'filename': filename});
+        },
+      );
+    });
+  }
+}

--- a/drivers/knex_dart_sqlite/test/browser/opfs_indexeddb_close_test.dart
+++ b/drivers/knex_dart_sqlite/test/browser/opfs_indexeddb_close_test.dart
@@ -171,6 +171,16 @@ void main() {
           // close() should complete cleanly afterwards.
           expect(result['initError'], isNull, reason: result.toString());
           expect(result['closeError'], isNull, reason: result.toString());
+          // A query against the now-closed client must fail with an
+          // accurate "is closed" error — not the misleading
+          // "failed to initialize" message _ensureDb() would give if it
+          // only checked _isClosed once, before awaiting the init this
+          // same race left pending.
+          expect(
+            result['queryAfterCloseError'],
+            allOf(isNotNull, contains('is closed')),
+            reason: result.toString(),
+          );
           await pumpEventQueue();
           expect(harness.uncaughtWorkerErrors, isEmpty);
 

--- a/drivers/knex_dart_sqlite/test/browser/opfs_indexeddb_close_test.dart
+++ b/drivers/knex_dart_sqlite/test/browser/opfs_indexeddb_close_test.dart
@@ -22,7 +22,14 @@
 /// (`destroyPool`/`_closeFileSystem`/`_initializeImpl`). Testing the wrapper
 /// on top would assert the exact same thing through an extra layer of
 /// indirection.
+///
+/// `@Retry(0)`: dart_test.yaml sets `retry: 2` package-wide for Chrome (for
+/// occasional browser-launch flakiness), but a retry on a lifecycle
+/// regression here would be exactly the wrong outcome — a real race
+/// condition failing once and then passing on retry must show up as a
+/// failure, not get silently absorbed.
 @TestOn('browser')
+@Retry(0)
 library;
 
 import 'package:test/test.dart';

--- a/drivers/knex_dart_sqlite/test/browser/opfs_worker.dart
+++ b/drivers/knex_dart_sqlite/test/browser/opfs_worker.dart
@@ -1,0 +1,266 @@
+/// Dedicated-worker entrypoint for the OPFS/IndexedDB handle-leak browser
+/// tests.
+///
+/// [SimpleOpfsFileSystem] (package:sqlite3's OPFS VFS) only works inside a
+/// dedicated Web Worker, not in a tab's main JS context — see the class doc
+/// comment in sqlite3's `lib/src/wasm/vfs/simple_opfs.dart`. This file is
+/// compiled to JS (via `dart compile js`, see tool/build_browser_worker.dart)
+/// and loaded as a real `Worker` from the main test context (see
+/// worker_harness.dart), so the scenarios below actually exercise
+/// SimpleOpfsFileSystem/IndexedDbFileSystem the way a real caller would.
+///
+/// Protocol: the main thread posts a JSON-encoded string
+/// `{id, action, params}`; this worker replies with a JSON-encoded string
+/// `{id, ok, result?, error?, stack?}`. Every action that opens a client
+/// expects `params['wasmUri']` — an absolute URL to sqlite3.wasm — because
+/// this worker has no reliable way to derive its own script location's
+/// package root independently (see WorkerHarness.wasmUrl for how the main
+/// thread computes it). One request is handled at a time in the order
+/// received (this file does not pipeline).
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:js_interop';
+
+import 'package:knex_dart/knex_dart.dart';
+import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
+import 'package:sqlite3/wasm.dart';
+import 'package:web/web.dart';
+
+late final DedicatedWorkerGlobalScope _scope;
+
+void main() {
+  _scope = globalContext as DedicatedWorkerGlobalScope;
+  _scope.onmessage = ((MessageEvent event) {
+    final raw = (event.data as JSString).toDart;
+    // Handle each request in its own async zone so a scenario that never
+    // completes (e.g. a hung close()) doesn't block later requests, and so
+    // uncaught async errors are captured and reported instead of becoming
+    // silent worker-global exceptions the test can't observe.
+    unawaited(_handle(raw));
+  }).toJS;
+}
+
+Future<void> _handle(String raw) async {
+  final request = jsonDecode(raw) as Map<String, dynamic>;
+  final id = request['id'] as String;
+  final action = request['action'] as String;
+  final params = (request['params'] as Map<String, dynamic>?) ?? const {};
+
+  await runZonedGuarded(
+    () async {
+      try {
+        final result = await _dispatch(action, params);
+        _reply({'id': id, 'ok': true, 'result': result});
+      } on Object catch (e, st) {
+        _reply({
+          'id': id,
+          'ok': false,
+          'error': e.toString(),
+          'stack': st.toString(),
+        });
+      }
+    },
+    (error, stack) {
+      // Caught here means it escaped the try/catch above (e.g. thrown from a
+      // callback/microtask after the awaited call already returned) — report
+      // it under a distinct id (rather than dropping it) so the test can
+      // assert "no uncaught error" instead of the failure silently vanishing
+      // into the worker's global error handler.
+      _reply({
+        'id': '$id.uncaught',
+        'ok': false,
+        'error': error.toString(),
+        'stack': stack.toString(),
+      });
+    },
+  );
+}
+
+void _reply(Map<String, dynamic> message) {
+  _scope.postMessage(jsonEncode(message).toJS);
+}
+
+Future<Object?> _dispatch(String action, Map<String, dynamic> params) async {
+  switch (action) {
+    case 'ping':
+      return 'pong';
+
+    case 'opfsWriteCloseDelete':
+      return _opfsWriteCloseDelete(
+        params['filename'] as String,
+        params['wasmUri'] as String,
+      );
+
+    case 'indexedDbWriteCloseDelete':
+      return _indexedDbWriteCloseDelete(
+        params['filename'] as String,
+        params['wasmUri'] as String,
+      );
+
+    case 'doubleClose':
+      return _doubleClose(
+        params['filename'] as String,
+        params['storageMode'] as String,
+        params['wasmUri'] as String,
+      );
+
+    case 'closeDuringInit':
+      return _closeDuringInit(
+        params['filename'] as String,
+        params['storageMode'] as String,
+        params['wasmUri'] as String,
+      );
+
+    case 'closeDuringQuery':
+      return _closeDuringQuery(
+        params['filename'] as String,
+        params['storageMode'] as String,
+        params['wasmUri'] as String,
+      );
+
+    case 'deleteOpfsStorage':
+      await SimpleOpfsFileSystem.deleteFromStorage(
+        params['filename'] as String,
+      );
+      return null;
+
+    case 'deleteIndexedDb':
+      await IndexedDbFileSystem.deleteDatabase(params['filename'] as String);
+      return null;
+
+    default:
+      throw StateError('Unknown action "$action"');
+  }
+}
+
+SQLiteClient _client(String filename, String storageMode, String wasmUri) {
+  return SQLiteClient.fromConfig(
+    KnexConfig(
+      client: 'sqlite3',
+      connection: {
+        'filename': filename,
+        'storageMode': storageMode,
+        'wasmUri': wasmUri,
+      },
+    ),
+  );
+}
+
+Future<Map<String, dynamic>> _opfsWriteCloseDelete(
+  String filename,
+  String wasmUri,
+) async {
+  final client = _client(filename, 'opfs', wasmUri);
+  await client.initialize();
+  await client.rawQuery('CREATE TABLE t (id INTEGER)', const []);
+  await client.rawQuery('INSERT INTO t (id) VALUES (1)', const []);
+  await client.close();
+
+  // Before the fix, this throws NoModificationAllowedError because the
+  // SimpleOpfsFileSystem's FileSystemSyncAccessHandles were never closed.
+  await SimpleOpfsFileSystem.deleteFromStorage(filename);
+  return {'deleted': true};
+}
+
+Future<Map<String, dynamic>> _indexedDbWriteCloseDelete(
+  String filename,
+  String wasmUri,
+) async {
+  final client = _client(filename, 'indexedDb', wasmUri);
+  await client.initialize();
+  await client.rawQuery('CREATE TABLE t (id INTEGER)', const []);
+  await client.rawQuery('INSERT INTO t (id) VALUES (1)', const []);
+  await client.close();
+
+  // Before the fix, this throws StateError('IndexedDB open blocked') because
+  // the IndexedDbFileSystem's IDBDatabase connection was never closed.
+  await IndexedDbFileSystem.deleteDatabase(filename);
+  return {'deleted': true};
+}
+
+Future<Map<String, dynamic>> _doubleClose(
+  String filename,
+  String storageMode,
+  String wasmUri,
+) async {
+  final client = _client(filename, storageMode, wasmUri);
+  await client.initialize();
+  await client.rawQuery('CREATE TABLE t (id INTEGER)', const []);
+
+  await Future.wait([client.close(), client.close()]);
+
+  return {'isClosed': client.isClosed};
+}
+
+Future<Map<String, dynamic>> _closeDuringInit(
+  String filename,
+  String storageMode,
+  String wasmUri,
+) async {
+  // Construct + close in the same synchronous prologue, before initialize()
+  // is ever awaited, to hit the "closed mid-init" window. connect() cannot
+  // express this because it awaits initialize() internally before returning
+  // the client — this is the only realistic surface: fromConfig() followed
+  // by an un-awaited initialize() is a real caller shape (e.g. a UI layer
+  // that kicks off connection setup and lets the user navigate away/cancel
+  // before it settles).
+  final client = _client(filename, storageMode, wasmUri);
+  final initFuture = client.initialize();
+  final closeFuture = client.close();
+
+  Object? initError;
+  Object? closeError;
+  try {
+    await initFuture;
+  } on Object catch (e) {
+    initError = e;
+  }
+  try {
+    await closeFuture;
+  } on Object catch (e) {
+    closeError = e;
+  }
+
+  return {
+    'isClosed': client.isClosed,
+    'initError': initError?.toString(),
+    'closeError': closeError?.toString(),
+  };
+}
+
+Future<Map<String, dynamic>> _closeDuringQuery(
+  String filename,
+  String storageMode,
+  String wasmUri,
+) async {
+  final client = _client(filename, storageMode, wasmUri);
+  await client.initialize();
+  await client.rawQuery('CREATE TABLE t (id INTEGER)', const []);
+
+  final queryFuture = client.rawQuery(
+    'INSERT INTO t (id) VALUES (1)',
+    const [],
+  );
+  final closeFuture = client.close();
+
+  Object? queryError;
+  Object? closeError;
+  try {
+    await queryFuture;
+  } on Object catch (e) {
+    queryError = e;
+  }
+  try {
+    await closeFuture;
+  } on Object catch (e) {
+    closeError = e;
+  }
+
+  return {
+    'isClosed': client.isClosed,
+    'queryError': queryError?.toString(),
+    'closeError': closeError?.toString(),
+  };
+}

--- a/drivers/knex_dart_sqlite/test/browser/opfs_worker.dart
+++ b/drivers/knex_dart_sqlite/test/browser/opfs_worker.dart
@@ -223,10 +223,22 @@ Future<Map<String, dynamic>> _closeDuringInit(
     closeError = e;
   }
 
+  // A query issued after this race must fail with an accurate "is closed"
+  // error, not the misleading "failed to initialize" message _ensureDb()
+  // used to give when _db was left null by the early-return branch inside
+  // _initializeImpl() rather than by a genuine init failure.
+  Object? queryAfterCloseError;
+  try {
+    await client.rawQuery('SELECT 1', const []);
+  } on Object catch (e) {
+    queryAfterCloseError = e;
+  }
+
   return {
     'isClosed': client.isClosed,
     'initError': initError?.toString(),
     'closeError': closeError?.toString(),
+    'queryAfterCloseError': queryAfterCloseError?.toString(),
   };
 }
 

--- a/drivers/knex_dart_sqlite/test/browser/web_close_after_init_failure_test.dart
+++ b/drivers/knex_dart_sqlite/test/browser/web_close_after_init_failure_test.dart
@@ -1,0 +1,63 @@
+/// Regression test for `destroyPool()` (sqlite_client_web.dart): `close()`
+/// must complete cleanly even when this client's own `initialize()` failed.
+///
+/// Before this was guarded, `destroyPool()`'s `try { await initialize(); }
+/// finally { ...cleanup... }` had no catch — cleanup ran correctly (the
+/// finally block always executes), but the original init error then
+/// propagated out of `destroyPool()` uncaught, so `close()` rethrew it to
+/// whoever called close(). A caller treating close() as a safe,
+/// always-succeeds cleanup call — the whole premise of this PR's fix — would
+/// be surprised to see it throw.
+///
+/// Uses a deliberately-unreachable `wasmUri` to force a genuine
+/// `_loadSqlite3()` failure — no OPFS/Worker/dedicated-worker machinery
+/// needed for this one, `_loadSqlite3()` runs before any storage-mode-
+/// specific setup.
+@TestOn('browser')
+@Retry(0)
+library;
+
+import 'package:knex_dart/knex_dart.dart';
+import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
+import 'package:test/test.dart';
+
+SQLiteClient _clientWithUnreachableWasm(String filename) {
+  return SQLiteClient.fromConfig(
+    KnexConfig(
+      client: 'sqlite3',
+      connection: {
+        'filename': filename,
+        'storageMode': 'memory',
+        'wasmUri': '/does-not-exist-sqlite3.wasm',
+      },
+    ),
+  );
+}
+
+void main() {
+  test('initialize() genuinely fails against an unreachable wasmUri '
+      '(sanity check for the rest of this file)', () async {
+    final client = _clientWithUnreachableWasm('init-fail-sanity');
+    await expectLater(client.initialize(), throwsA(anything));
+  });
+
+  test(
+    'close() completes without throwing after initialize() failed',
+    () async {
+      final client = _clientWithUnreachableWasm('init-fail-close');
+      try {
+        await client.initialize();
+      } on Object {
+        // Expected — asserted by the sanity check above.
+      }
+
+      // The actual point of this test: close() itself must not rethrow
+      // the init failure. It should complete normally.
+      await client.close();
+      expect(client.isClosed, isTrue);
+
+      // A second close() must also stay a safe no-op.
+      await client.close();
+    },
+  );
+}

--- a/drivers/knex_dart_sqlite/test/browser/web_trx_rollback_failure_test.dart
+++ b/drivers/knex_dart_sqlite/test/browser/web_trx_rollback_failure_test.dart
@@ -1,0 +1,95 @@
+/// Regression tests for the web client's `_runTransactionScope` top-level
+/// catch block (sqlite_client_web.dart) mirroring the native fix +
+/// regression tests in test/sqlite_trx_test.dart.
+///
+/// If the callback already ended the transaction via raw SQL (or the
+/// connection is torn down concurrently), `db.execute('ROLLBACK')` itself
+/// throws. Before this was guarded — the same way the SAVEPOINT branch just
+/// above it already guards `ROLLBACK TO SAVEPOINT` — that secondary failure
+/// propagated *instead of* the callback's original error, and skipped
+/// `_txUpdateStack.removeLast()`, permanently leaving a stale entry that made
+/// `watch()` silently stop seeing non-transactional writes for the rest of
+/// the client's lifetime (the update hook buffers into `_txUpdateStack.last`
+/// instead of forwarding to `_updateController` whenever the stack is
+/// non-empty).
+///
+/// Uses `storageMode: 'memory'`, so unlike the OPFS/IndexedDB tests this
+/// needs neither a dedicated Worker nor `lib/web_assets/opfs_worker.dart.js`
+/// — only sqlite3.wasm.
+@TestOn('browser')
+library;
+
+import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';
+import 'package:test/test.dart';
+
+int _fileCounter = 0;
+String _uniqueFilename(String tag) =>
+    'knex-sqlite-rollback-fail-$tag-'
+    '${DateTime.now().microsecondsSinceEpoch}-${_fileCounter++}';
+
+void main() {
+  test(
+    'a failing ROLLBACK preserves the original trx error (not the rollback '
+    'failure)',
+    () async {
+      final db = await KnexSQLite.connect(
+        filename: _uniqueFilename('error'),
+        webStorageMode: 'memory',
+      );
+      addTearDown(db.close);
+      await db.executeSchema((s) {
+        s.createTable('t', (t) => t.integer('id').primary());
+      });
+
+      Object? caught;
+      try {
+        await db.trx((tx) async {
+          await tx.rawSql('COMMIT'); // ends the transaction early
+          throw Exception('boom');
+        });
+      } on Object catch (e) {
+        caught = e;
+      }
+      expect(caught, isA<Exception>());
+      expect(caught.toString(), contains('boom'));
+    },
+  );
+
+  test(
+    'watch() still emits for non-transactional writes after a rollback '
+    'failure',
+    () async {
+      final db = await KnexSQLite.connect(
+        filename: _uniqueFilename('watch'),
+        webStorageMode: 'memory',
+      );
+      addTearDown(db.close);
+      await db.executeSchema((s) {
+        s.createTable('t', (t) => t.integer('id').primary());
+      });
+
+      try {
+        await db.trx((tx) async {
+          await tx.rawSql('COMMIT');
+          throw Exception('boom');
+        });
+      } on Object {
+        // Expected — asserted by the previous test.
+      }
+
+      final emissions = <int>[];
+      final sub = db
+          .watch(db('t').select(['*']))
+          .listen((rows) => emissions.add(rows.length));
+      await Future<void>.delayed(Duration.zero);
+
+      await db.insert(db('t').insert({'id': 1}));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      await sub.cancel();
+
+      // Before the fix: only the initial (empty) emission ever arrived.
+      expect(emissions, hasLength(2));
+      expect(emissions.last, 1);
+    },
+  );
+}

--- a/drivers/knex_dart_sqlite/test/browser/web_trx_rollback_failure_test.dart
+++ b/drivers/knex_dart_sqlite/test/browser/web_trx_rollback_failure_test.dart
@@ -16,7 +16,12 @@
 /// Uses `storageMode: 'memory'`, so unlike the OPFS/IndexedDB tests this
 /// needs neither a dedicated Worker nor `lib/web_assets/opfs_worker.dart.js`
 /// — only sqlite3.wasm.
+///
+/// `@Retry(0)`: same reasoning as opfs_indexeddb_close_test.dart — a
+/// regression here is deterministic, and dart_test.yaml's package-wide
+/// Chrome `retry: 2` (for browser-launch flakiness) must not mask it.
 @TestOn('browser')
+@Retry(0)
 library;
 
 import 'package:knex_dart_sqlite/knex_dart_sqlite.dart';

--- a/drivers/knex_dart_sqlite/test/browser/worker_harness.dart
+++ b/drivers/knex_dart_sqlite/test/browser/worker_harness.dart
@@ -1,0 +1,196 @@
+/// Main-thread side of the dedicated-worker RPC used by the OPFS/IndexedDB
+/// browser tests (see opfs_worker.dart for the protocol and worker side).
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:js_interop';
+
+import 'package:web/web.dart';
+
+/// Spawns test/browser/opfs_worker.dart (pre-compiled to JS — see
+/// tool/build_browser_worker.dart) as a real dedicated Worker and exposes an
+/// RPC-style [call] API over postMessage.
+class WorkerHarness {
+  final Worker _worker;
+
+  /// Absolute URL to this package's root as served by `dart test`'s browser
+  /// static server for the current test run.
+  ///
+  /// `dart test --platform=chrome` serves each browser test page at a
+  /// per-run, hash-prefixed URL that mirrors the test file's path under the
+  /// package root — e.g. a page compiled from `test/browser/foo_test.dart`
+  /// is served at `http://host:port/<hash>/test/browser/foo_test.html`.
+  /// There is no stable `/packages/<name>/...` route for non-Dart assets
+  /// (unlike a real pub/Flutter web app) — that only exists for a page
+  /// loaded via `custom_html_template_path`, which this harness doesn't use.
+  /// So instead this walks the current page's own URL back to the segment
+  /// right before the first `test` path component, which is package root for
+  /// any test file under `test/**`.
+  static String packageRootUrl() {
+    final location = Uri.parse(window.location.href);
+    final segments = location.pathSegments;
+    final testIndex = segments.indexOf('test');
+    if (testIndex < 0) {
+      throw StateError(
+        'Could not locate package root from test page URL '
+        '"${location.toString()}" (no "test" path segment found).',
+      );
+    }
+    final rootSegments = segments.sublist(0, testIndex);
+    return '${location.origin}/${rootSegments.join('/')}/';
+  }
+
+  static String get _workerUrl =>
+      '${packageRootUrl()}lib/web_assets/opfs_worker.dart.js';
+
+  /// Absolute URL to the vendored sqlite3.wasm binary, passed to the worker
+  /// explicitly (rather than having the worker guess its own path) since the
+  /// worker's own script URL lives under the same per-run hash but the
+  /// worker has no reason to re-derive it independently.
+  static String get wasmUrl =>
+      '${packageRootUrl()}lib/web_assets/sqlite3.wasm';
+
+  final _pending = <String, Completer<Map<String, dynamic>>>{};
+
+  /// Messages the worker reported via its `runZonedGuarded` error handler —
+  /// i.e. errors that escaped the per-request try/catch entirely. A clean
+  /// test run must leave this empty.
+  final List<Map<String, dynamic>> uncaughtWorkerErrors = [];
+
+  late final StreamSubscription<MessageEvent> _messageSub;
+  late final StreamSubscription<Event> _errorSub;
+  int _counter = 0;
+  Object? _fatalWorkerError;
+
+  WorkerHarness._(this._worker) {
+    _messageSub = EventStreamProviders.messageEvent
+        .forTarget(_worker)
+        .listen(_onMessage);
+    _errorSub = EventStreamProviders.errorEvent
+        .forTarget(_worker)
+        .listen(_onWorkerError);
+  }
+
+  /// Spawns a fresh dedicated worker. Each test should spawn its own so a
+  /// crash or hang in one test can't bleed into the next.
+  factory WorkerHarness.spawn() {
+    final worker = Worker(
+      _workerUrl.toJS,
+      WorkerOptions(name: 'knex-sqlite-opfs-test-worker'),
+    );
+    return WorkerHarness._(worker);
+  }
+
+  void _onMessage(MessageEvent event) {
+    final raw = (event.data as JSString).toDart;
+    final message = jsonDecode(raw) as Map<String, dynamic>;
+    final id = message['id'] as String;
+
+    if (id.endsWith('.uncaught')) {
+      uncaughtWorkerErrors.add(message);
+      // The original request this uncaught error was attributed to may still
+      // be pending forever (the scenario never replied on the happy path) —
+      // fail it now rather than let the test hang until the call timeout.
+      final originalId = id.substring(0, id.length - '.uncaught'.length);
+      final completer = _pending.remove(originalId);
+      completer?.completeError(
+        StateError('Uncaught error in worker: ${message['error']}'),
+      );
+      return;
+    }
+
+    final completer = _pending.remove(id);
+    // No pending completer for a normal (non-.uncaught) reply should never
+    // happen given the request/response protocol; surfacing via print (rather
+    // than silently dropping) makes a protocol bug visible in test output.
+    if (completer == null) {
+      // ignore: avoid_print
+      print('WorkerHarness: reply for unknown request id "$id": $message');
+      return;
+    }
+    completer.complete(message);
+  }
+
+  void _onWorkerError(Event event) {
+    _fatalWorkerError = event;
+    var detail = 'Dedicated worker raised an ErrorEvent';
+    if (event.isA<ErrorEvent>()) {
+      final errorEvent = event as ErrorEvent;
+      detail =
+          '$detail: message="${errorEvent.message}" '
+          'filename="${errorEvent.filename}" lineno=${errorEvent.lineno}';
+    }
+    // A blank message/filename above (browsers sanitize load-failure detail)
+    // most commonly means lib/web_assets/opfs_worker.dart.js doesn't exist or
+    // is stale — fail loudly with the fix rather than let this present as an
+    // opaque hang or a generic "Worker already failed" from every call site.
+    detail =
+        '$detail\nIf this worker never loaded at all, run '
+        '`dart run tool/build_browser_worker.dart` (and '
+        '`dart run tool/download_wasm.dart` for sqlite3.wasm) first.';
+    final error = StateError(detail);
+    for (final completer in _pending.values) {
+      if (!completer.isCompleted) completer.completeError(error);
+    }
+    _pending.clear();
+  }
+
+  /// Sends [action] with [params] to the worker and awaits its reply.
+  ///
+  /// Fails (rather than hanging for the whole suite timeout) if the worker
+  /// doesn't reply within [timeout], which keeps a genuinely hung scenario
+  /// from being indistinguishable from "still running" in CI output.
+  Future<Map<String, dynamic>> call(
+    String action, [
+    Map<String, dynamic> params = const {},
+    Duration timeout = const Duration(seconds: 15),
+  ]) {
+    if (_fatalWorkerError != null) {
+      return Future.error(
+        StateError('Worker already failed with $_fatalWorkerError'),
+      );
+    }
+    final id = 'req-${_counter++}';
+    final completer = Completer<Map<String, dynamic>>();
+    _pending[id] = completer;
+    // Every action that opens a SQLiteClient needs wasmUri; harmless to pass
+    // it to actions that don't (ping, deleteOpfsStorage, deleteIndexedDb).
+    // Callers can still override it explicitly via params.
+    final fullParams = {'wasmUri': wasmUrl, ...params};
+    _worker.postMessage(
+      jsonEncode({'id': id, 'action': action, 'params': fullParams}).toJS,
+    );
+    return completer.future.timeout(
+      timeout,
+      onTimeout: () {
+        _pending.remove(id);
+        throw TimeoutException(
+          'Worker call "$action" (id $id) timed out after $timeout',
+        );
+      },
+    );
+  }
+
+  /// Calls [action] and returns its `result` payload, throwing a descriptive
+  /// [StateError] if the worker reported `ok: false`.
+  Future<Object?> callOk(
+    String action, [
+    Map<String, dynamic> params = const {},
+  ]) async {
+    final response = await call(action, params);
+    if (response['ok'] != true) {
+      throw StateError(
+        'Worker action "$action" failed: ${response['error']}\n'
+        '${response['stack']}',
+      );
+    }
+    return response['result'];
+  }
+
+  Future<void> dispose() async {
+    await _messageSub.cancel();
+    await _errorSub.cancel();
+    _worker.terminate();
+  }
+}

--- a/drivers/knex_dart_sqlite/test/sqlite_trx_test.dart
+++ b/drivers/knex_dart_sqlite/test/sqlite_trx_test.dart
@@ -214,6 +214,68 @@ void main() {
       expect(rows.first['name'], 'AfterFail');
     });
 
+    // ── 11b. A failing ROLLBACK must not mask the original error or corrupt
+    //         the update-hook stack ─────────────────────────────────────────
+    //
+    // If the callback already ended the transaction via raw SQL (or the
+    // connection is torn down concurrently), sqlite3.execute('ROLLBACK')
+    // itself throws ("cannot rollback - no transaction is active"). Before
+    // this was guarded (mirroring the SAVEPOINT branch's existing
+    // try/catch), that secondary failure propagated *instead of* the
+    // original callback error, and skipped _txUpdateStack.removeLast() —
+    // leaving a permanent stale entry that made watch() silently stop seeing
+    // non-transactional writes for the rest of the client's lifetime (the
+    // update hook buffers into _txUpdateStack.last instead of forwarding to
+    // _updateController whenever the stack is non-empty).
+
+    test(
+      'rollback failure inside a failed trx preserves the original error',
+      () async {
+        Object? caught;
+        try {
+          await db.trx((tx) async {
+            await tx.rawSql('COMMIT'); // ends the transaction early
+            throw Exception('boom');
+          });
+        } catch (e) {
+          caught = e;
+        }
+        expect(caught, isA<Exception>());
+        expect(caught.toString(), contains('boom'));
+      },
+    );
+
+    test(
+      'watch() still emits for non-transactional writes after a rollback '
+      'failure',
+      () async {
+        try {
+          await db.trx((tx) async {
+            await tx.rawSql('COMMIT');
+            throw Exception('boom');
+          });
+        } catch (_) {
+          // Expected — asserted by the previous test; ignored here.
+        }
+
+        final emissions = <int>[];
+        final sub = db
+            .watch(db(_table).select(['*']))
+            .listen((rows) => emissions.add(rows.length));
+        await Future<void>.delayed(Duration.zero);
+
+        await db.insert(db(_table).insert({'id': 60, 'name': 'AfterBadRollback'}));
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+        await sub.cancel();
+
+        // Before the fix: only the initial (empty) emission ever arrived —
+        // the insert's update-hook event was buffered into a stale
+        // _txUpdateStack entry that no top-level commit will ever flush.
+        expect(emissions, hasLength(2));
+        expect(emissions.last, 1);
+      },
+    );
+
     // ── 12. webStorageMode must fail fast on native ───────────────────────────
 
     test(

--- a/drivers/knex_dart_sqlite/tool/build_browser_worker.dart
+++ b/drivers/knex_dart_sqlite/tool/build_browser_worker.dart
@@ -1,0 +1,44 @@
+/// Compiles test/browser/opfs_worker.dart to JS so it can be loaded as a
+/// real dedicated `Worker` from the browser test suite.
+///
+/// `dart test` only compiles the *_test.dart entrypoints it runs; it has no
+/// notion of a second, worker-only Dart entrypoint that a test spawns at
+/// runtime via the `Worker` constructor. So — analogous to
+/// drivers/knex_dart_duckdb/tool/download_wasm.dart vendoring the DuckDB WASM
+/// binary — this is a one-time prep step whose output
+/// (lib/web_assets/opfs_worker.dart.js) is gitignored and rebuilt on each
+/// machine/CI runner:
+///
+///   dart run tool/build_browser_worker.dart
+///
+/// Run this (and tool/download_wasm.dart) before:
+///   dart test test/browser/ --platform=chrome
+library;
+
+import 'dart:io';
+
+Future<void> main() async {
+  final outDir = Directory('lib/web_assets');
+  if (!outDir.existsSync()) outDir.createSync(recursive: true);
+
+  const entrypoint = 'test/browser/opfs_worker.dart';
+  const output = 'lib/web_assets/opfs_worker.dart.js';
+
+  print('Compiling $entrypoint -> $output ...');
+  final result = await Process.run('dart', [
+    'compile',
+    'js',
+    entrypoint,
+    '-o',
+    output,
+  ]);
+  stdout.write(result.stdout);
+  stderr.write(result.stderr);
+
+  if (result.exitCode != 0) {
+    stderr.writeln('dart compile js failed (exit code ${result.exitCode}).');
+    exitCode = result.exitCode;
+    return;
+  }
+  print('Wrote $output');
+}

--- a/drivers/knex_dart_sqlite/tool/download_wasm.dart
+++ b/drivers/knex_dart_sqlite/tool/download_wasm.dart
@@ -1,0 +1,97 @@
+/// Downloads the sqlite3 WASM binary to lib/web_assets/ for local browser
+/// testing (mirrors drivers/knex_dart_duckdb/tool/download_wasm.dart).
+///
+/// Run once before running Chrome tests:
+///   dart run tool/download_wasm.dart
+///
+/// The file is gitignored — it needs to be downloaded on each machine/CI
+/// runner. The version is inferred from the resolved `sqlite3` package (via
+/// .dart_tool/package_config.json) so this always matches whatever version
+/// pub actually resolved, rather than a hardcoded constant that can drift out
+/// of sync with pubspec.yaml's `sqlite3: ^3.0.0` constraint.
+library;
+
+import 'dart:convert';
+import 'dart:io';
+
+Future<String> _resolveSqlite3Version() async {
+  // This package resolves via the melos/pub workspace (`resolution:
+  // workspace` in pubspec.yaml), so .dart_tool/package_config.json usually
+  // lives at the workspace root rather than in this package's own directory
+  // — check both, preferring the local one if present.
+  var packageConfig = File('.dart_tool/package_config.json');
+  if (!packageConfig.existsSync()) {
+    packageConfig = File('../../.dart_tool/package_config.json');
+  }
+  if (!packageConfig.existsSync()) {
+    throw StateError(
+      'package_config.json not found (checked .dart_tool/ and '
+      '../../.dart_tool/) — run `dart pub get` first.',
+    );
+  }
+  final json =
+      jsonDecode(await packageConfig.readAsString()) as Map<String, dynamic>;
+  final packages = json['packages'] as List<dynamic>;
+  final sqlite3Package = packages.cast<Map<String, dynamic>>().firstWhere(
+    (p) => p['name'] == 'sqlite3',
+    orElse: () => throw StateError(
+      'sqlite3 package not found in package_config.json.',
+    ),
+  );
+  var rootUri = sqlite3Package['rootUri'] as String;
+  rootUri = rootUri.replaceFirst(RegExp(r'^file://'), '');
+  final dirName = rootUri.split('/').where((s) => s.isNotEmpty).last;
+  final match = RegExp(r'^sqlite3-(.+)$').firstMatch(dirName);
+  if (match == null) {
+    throw StateError('Could not infer sqlite3 version from "$rootUri".');
+  }
+  return match.group(1)!;
+}
+
+Future<void> main() async {
+  final version = await _resolveSqlite3Version();
+  print('Resolved sqlite3 version: $version');
+
+  final outDir = Directory('lib/web_assets');
+  if (!outDir.existsSync()) outDir.createSync(recursive: true);
+  final outFile = File('${outDir.path}/sqlite3.wasm');
+
+  final candidateUrls = [
+    'https://github.com/simolus3/sqlite3.dart/releases/download/sqlite3-$version/sqlite3.wasm',
+    'https://github.com/simolus3/sqlite3.dart/releases/download/v$version/sqlite3.wasm',
+    'https://github.com/simolus3/sqlite3.dart/releases/download/$version/sqlite3.wasm',
+    'https://github.com/simolus3/sqlite3.dart/releases/latest/download/sqlite3.wasm',
+  ];
+
+  final client = HttpClient();
+  try {
+    for (final url in candidateUrls) {
+      print('Trying $url ...');
+      try {
+        final request = await client.getUrl(Uri.parse(url));
+        final response = await request.close();
+        if (response.statusCode != 200) {
+          print('  -> HTTP ${response.statusCode}, trying next candidate.');
+          await response.drain<void>();
+          continue;
+        }
+        final sink = outFile.openWrite();
+        await response.pipe(sink);
+        print('Saved sqlite3.wasm (${_mb(outFile.lengthSync())}) to '
+            '${outFile.path}');
+        return;
+      } on Object catch (e) {
+        print('  -> failed: $e');
+      }
+    }
+    stderr.writeln(
+      'Could not download sqlite3.wasm from any candidate URL for version '
+      '$version.',
+    );
+    exitCode = 1;
+  } finally {
+    client.close(force: true);
+  }
+}
+
+String _mb(int bytes) => '${(bytes / (1024 * 1024)).toStringAsFixed(2)} MB';

--- a/drivers/knex_dart_sqlite/tool/download_wasm.dart
+++ b/drivers/knex_dart_sqlite/tool/download_wasm.dart
@@ -56,39 +56,36 @@ Future<void> main() async {
   if (!outDir.existsSync()) outDir.createSync(recursive: true);
   final outFile = File('${outDir.path}/sqlite3.wasm');
 
-  final candidateUrls = [
-    'https://github.com/simolus3/sqlite3.dart/releases/download/sqlite3-$version/sqlite3.wasm',
-    'https://github.com/simolus3/sqlite3.dart/releases/download/v$version/sqlite3.wasm',
-    'https://github.com/simolus3/sqlite3.dart/releases/download/$version/sqlite3.wasm',
-    'https://github.com/simolus3/sqlite3.dart/releases/latest/download/sqlite3.wasm',
-  ];
+  // simolus3/sqlite3.dart tags every sqlite3 package release as
+  // "sqlite3-$version" — checked every release back to 2.7.7, no exceptions
+  // — so this is the only URL that has ever been correct. No "latest" or
+  // alternate-tag-format fallback: either could silently download a
+  // sqlite3.wasm that doesn't match the version pub actually resolved
+  // (declared in pubspec.yaml), testing a different binary than intended.
+  // Fail loudly instead if this doesn't match.
+  final url =
+      'https://github.com/simolus3/sqlite3.dart/releases/download/'
+      'sqlite3-$version/sqlite3.wasm';
 
   final client = HttpClient();
   try {
-    for (final url in candidateUrls) {
-      print('Trying $url ...');
-      try {
-        final request = await client.getUrl(Uri.parse(url));
-        final response = await request.close();
-        if (response.statusCode != 200) {
-          print('  -> HTTP ${response.statusCode}, trying next candidate.');
-          await response.drain<void>();
-          continue;
-        }
-        final sink = outFile.openWrite();
-        await response.pipe(sink);
-        print('Saved sqlite3.wasm (${_mb(outFile.lengthSync())}) to '
-            '${outFile.path}');
-        return;
-      } on Object catch (e) {
-        print('  -> failed: $e');
-      }
+    print('Downloading $url ...');
+    final request = await client.getUrl(Uri.parse(url));
+    final response = await request.close();
+    if (response.statusCode != 200) {
+      await response.drain<void>();
+      stderr.writeln(
+        'Could not download sqlite3.wasm for version $version: '
+        'HTTP ${response.statusCode} from $url.',
+      );
+      exitCode = 1;
+      return;
     }
-    stderr.writeln(
-      'Could not download sqlite3.wasm from any candidate URL for version '
-      '$version.',
+    final sink = outFile.openWrite();
+    await response.pipe(sink);
+    print(
+      'Saved sqlite3.wasm (${_mb(outFile.lengthSync())}) to ${outFile.path}',
     );
-    exitCode = 1;
   } finally {
     client.close(force: true);
   }


### PR DESCRIPTION
## Summary

`SQLiteClient` (web, `drivers/knex_dart_sqlite/lib/src/sqlite_client_web.dart`) creates a `VirtualFileSystem` in `_initializeImpl()` but never stores a reference to it, so `destroyPool()` has no way to release it. Closing the sqlite3 `Database` only triggers each file's `xClose()` — for `SimpleOpfsFileSystem` (OPFS storage mode) that just flushes, it does not release the underlying `FileSystemSyncAccessHandle`s. Those stay open for the life of the worker/tab, so any later attempt to delete/replace the OPFS storage (e.g. corruption recovery: close → delete → reopen) fails with `NoModificationAllowedError`.

Fixes #18.

## What changed

- Store the `VirtualFileSystem` as an instance field (`_fileSystem`), set immediately when `_createFileSystem()` returns — before registration/open — so it's captured even if a later init step throws.
- Added `_closeFileSystem()`: releases `SimpleOpfsFileSystem` (sync `.close()`, which closes the meta/database/journal sync access handles) or `IndexedDbFileSystem` (async `.close()`) via a runtime type check, wrapped so it can never throw out of a `finally` block. `InMemoryFileSystem` needs nothing.
- Called from `destroyPool()`'s `finally`, after `_db?.close()` (sqlite3 must finish flushing before the underlying handles go away), and from the early-close branch in `_initializeImpl()` so nothing leaks if the client is closed mid-init.
- Changed `_updateController` from `late final` (assigned only on the success path) to eagerly-initialized `final` — otherwise, if init throws after creating the file system but before `_setupUpdateHook()` runs, `destroyPool()`'s unconditional `_updateController.isClosed` read throws `LateInitializationError` and masks the real init failure, on exactly the path this fix needs to handle cleanly.

## Went further than the issue's suggested fix

Verified against the actual resolved `sqlite3` 3.5.2 sources rather than taking the issue's suggestion at face value. The OPFS part is correct, but the issue's claim that `IndexedDbFileSystem` needs no equivalent handling ("no exclusive OS-level lock") is wrong: `IndexedDbFileSystem.close()` is what releases the underlying `IDBDatabase` connection, and `IndexedDbFileSystem.deleteDatabase()` uses `completeOrBlocked()`, which rejects immediately on IndexedDB's `blocked` event — fired exactly when a connection is still open. So the identical close→delete→reopen recovery flow fails for `indexedDb` storage mode too (as `StateError('IndexedDB open blocked')` instead of `NoModificationAllowedError`), and skipping `close()` can also silently drop pending writes independent of any delete flow. Both are fixed here via the same helper.

`WasmSqlite3.unregisterVirtualFileSystem()` was considered and skipped — its VFS registration table is per-bindings-instance state, not a browser-level handle, so it's reclaimed with the rest of the WASM module on ordinary GC.

## Scope check

Searched the workspace for the same "resource created in a local variable, cleanup can't reach it" shape elsewhere (other web/WASM VFS registration, workers, ports). Found nothing else: `knex_dart_sqlite`'s native client has no VFS/worker lifecycle (OS-level file handles managed by sqlite3 FFI directly), and `knex_dart_duckdb`'s web entrypoint only re-exports the shared client (`dart_duckdb` owns its own WASM/VFS lifecycle internally). No other driver has a web/WASM variant. No follow-up issues to file.

## Update: real browser tests + a second bug found while adding them

The original PR shipped without a regression test — this package had no browser test suite, and OPFS specifically only works inside a dedicated Web Worker (confirmed directly against `sqlite3` 3.5.2's own `lib/src/wasm/vfs/simple_opfs.dart` class doc comment: "only available in dedicated web workers, not in the JavaScript context for a tab or a shared web worker"), so a plain `dart test -p chrome` on the main test page can't exercise it at all. That's now built:

- **Worker-based browser harness** (`test/browser/worker_harness.dart` + `opfs_worker.dart`, `tool/download_wasm.dart` + `tool/build_browser_worker.dart`): spawns a real dedicated `Worker` running the actual `SQLiteClient.fromConfig` code path (not a stub), RPCs into it with a per-call timeout, and surfaces `Worker` `ErrorEvent`s instead of an opaque hang.
- **Race-condition tests** (`test/browser/opfs_indexeddb_close_test.dart`) for both `opfs` and `indexedDb` storage modes: the literal issue #18 repro (write → close → delete storage, now succeeds), two concurrent `close()` calls, `close()` called before `initialize()` is ever awaited, and `close()` called while a write query is in flight — 8 scenarios total, all passing.
- `test/browser/indexeddb_main_thread_test.dart`: direct confirmation that `IndexedDbFileSystem` (unlike `SimpleOpfsFileSystem`) has no dedicated-worker requirement, by running it on the main thread with no worker involved.
- **A second real bug found while writing these tests**, unrelated to the OPFS/IndexedDB fix itself but in the same transaction-scope code: a failing `ROLLBACK` (e.g. the callback already ended the transaction via raw SQL) was propagating *instead of* the original callback error and skipping `_txUpdateStack.removeLast()` — permanently corrupting `watch()`'s update-hook stack for the rest of the client's lifetime. Fixed in both the native and web clients (mirroring the existing `SAVEPOINT` branch's own guard), with regression tests on both (`test/sqlite_trx_test.dart`, `test/browser/web_trx_rollback_failure_test.dart`).
- CI now runs the full browser suite (`tool/download_wasm.dart` → `tool/build_browser_worker.dart` → the existing `dart test --platform=chrome` step, which picks up `test/browser/` automatically via this driver's own `dart_test.yaml`).

## Update: CodeRabbit review + adversarial review, both addressed

CodeRabbit flagged 3 issues, all real:
- **Major**: if `registerVirtualFileSystem()`/`sqlite.open()` throws inside `_initializeImpl()`, `connect()` never returns a client, so nothing could ever reach `close()` to release the already-stored `_fileSystem`. Fixed with a try/catch around registration+open that releases it on the way out.
- Chrome's package-wide `retry: 2` could mask a real lifecycle regression in the race-condition tests specifically — added `@Retry(0)` to those two files.
- The WASM-download fallback chain included an unversioned `latest` URL that could silently download a mismatched binary. Checked every real release tag on `simolus3/sqlite3.dart` back to 2.7.7: only `sqlite3-$version` has ever been used — the other two candidate patterns were dead code, not defensive coverage. Simplified to the one URL that's ever actually worked, with a hard failure instead of a silent mismatch.

A follow-up adversarial review (checking every close()/init-failure interaction by hand, not just re-reading the diff) found 2 more confirmed issues, both edge cases around `close()`'s error behavior rather than resource leaks (the actual fix already works correctly in both):
- `close()` could itself rethrow if this client's own `initialize()` had failed — surprising for something meant to be a safe, always-succeeds cleanup call. `destroyPool()` now catches and swallows that, while its cleanup (which already ran correctly via the `finally` block) is unchanged.
- A close-during-init race left a misleading "failed to initialize... is sqlite3.wasm served?" error on the next query, when the real cause was "closed concurrently." `_ensureDb()` now re-checks `_isClosed` after awaiting `initialize()`, not just before.

A third finding (`'auto'` storage mode's fallback path has no test coverage) was left as a known gap rather than fixed speculatively.

## Test plan

- [x] `dart analyze --fatal-warnings` clean on `drivers/knex_dart_sqlite`
- [x] `dart test` (VM) — 120/120 passing throughout (118 baseline + 2 ROLLBACK-guard regression tests; unaffected by the CodeRabbit/adversarial-review fixes, which are web-client-only)
- [x] `dart test test/browser/ --platform=chrome` — 14/14 passing (12 + 2 new), verified individually per file (the combined run's per-test line labels get scrambled by `dart test`'s concurrent-tab reporting across 4 files, but "All tests passed" with zero failures matches every individual file's result exactly)
- [x] Both new regression tests verified failing before their respective fix and passing after

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction error handling so original callback errors are preserved when rollback fails.
  * Prevented stale update state after failed rollbacks, keeping change notifications working.
  * Ensured web storage resources close correctly during shutdown and interrupted initialization.

* **Testing**
  * Added browser coverage for IndexedDB, OPFS, worker shutdown, concurrent closes, and rollback failures.
  * Improved automated browser test setup and asset preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
