### PR TITLE
fix(otel,benchmark): update CapturingHistogram for opentelemetry API signature change

### DIFF
--- a/benchmarks/bin/sqlite_live.dart
+++ b/benchmarks/bin/sqlite_live.dart
@@ -12,7 +12,7 @@ class CapturingHistogram extends APIHistogram<double> {
   final List<(double value, Map<String, Object> attrs)> recordings = [];
 
   CapturingHistogram(APIMeter meter)
-    : super('db.client.operation.duration', null, 's', true, meter);
+    : super('db.client.operation.duration', null, 's', meter);
 
   @override
   void record(double value, [Attributes? attributes]) {

--- a/integrations/knex_dart_otel/test/otel_error_test.dart
+++ b/integrations/knex_dart_otel/test/otel_error_test.dart
@@ -14,7 +14,7 @@ class CapturingHistogram extends APIHistogram<double> {
   final List<(double value, Map<String, Object> attrs)> recordings = [];
 
   CapturingHistogram(APIMeter meter)
-    : super('db.client.operation.duration', null, 's', true, meter);
+    : super('db.client.operation.duration', null, 's', meter);
 
   @override
   void record(double value, [Attributes? attributes]) {

--- a/integrations/knex_dart_otel/test/otel_interceptor_test.dart
+++ b/integrations/knex_dart_otel/test/otel_interceptor_test.dart
@@ -17,7 +17,7 @@ class CapturingHistogram extends APIHistogram<double> {
   final List<(double value, Map<String, Object> attrs)> recordings = [];
 
   CapturingHistogram(APIMeter meter)
-    : super('db.client.operation.duration', null, 's', true, meter);
+    : super('db.client.operation.duration', null, 's', meter);
 
   @override
   void record(double value, [Attributes? attributes]) {

--- a/integrations/knex_dart_otel/test/otel_span_attributes_test.dart
+++ b/integrations/knex_dart_otel/test/otel_span_attributes_test.dart
@@ -20,7 +20,7 @@ class CapturingHistogram extends APIHistogram<double> {
   final List<(double value, Map<String, Object> attrs)> recordings = [];
 
   CapturingHistogram(APIMeter meter)
-    : super('db.client.operation.duration', null, 's', true, meter);
+    : super('db.client.operation.duration', null, 's', meter);
 
   @override
   void record(double value, [Attributes? attributes]) {


### PR DESCRIPTION
## Summary

CI's `melos run analyze` was failing on `main` (confirmed via the latest run on main, unrelated to any in-flight PR) with:

```
error - bin/sqlite_live.dart:15:56 - The argument type 'bool' can't be assigned to the parameter type 'APIMeter'.
error - bin/sqlite_live.dart:15:62 - Too many positional arguments: 4 expected, but 5 found.
```

and the equivalent in three `knex_dart_otel` test files.

**Root cause**: `dartastic_opentelemetry_api` `1.0.0-rc.3` dropped the `enabled` (bool) positional parameter from `APIHistogram`'s constructor:

- rc.1: `APIHistogram(name, description, unit, enabled, meter, {boundaries})` — 5 positional
- rc.3: `APIHistogram(name, description, unit, meter, {boundaries})` — 4 positional

Both `knex_dart_otel` and `knex_dart_benchmark` depend on `dartastic_opentelemetry_api: ^1.0.0-rc.1`, which permits rc.3. Once pub resolved to rc.3, every local `CapturingHistogram` test helper's `super(...)` call (still passing 5 positional args, including the now-removed `true` for `enabled`) broke.

## Fix

Updated the four identical `CapturingHistogram(APIMeter meter) : super(...)` call sites to drop the removed `enabled` argument:
- `benchmarks/bin/sqlite_live.dart`
- `integrations/knex_dart_otel/test/otel_error_test.dart`
- `integrations/knex_dart_otel/test/otel_interceptor_test.dart`
- `integrations/knex_dart_otel/test/otel_span_attributes_test.dart`

## Test plan

- [x] `melos run analyze` clean across all 14 workspace packages
- [x] `dart test` in `integrations/knex_dart_otel`: 79/79 passing

https://claude.ai/code/session_01Tk6BusWZZCP416heTj28GT
